### PR TITLE
DP-15708 - Upgrade scala to 2.13.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ scalatest_toolchain()
 ```
 
 This will load the `rules_scala` repository at the commit sha
-`rules_scala_version` into your Bazel project and register a [scala_toolchain](docs/scala_toolchain.md) at the default Scala version (2.12.18)
+`rules_scala_version` into your Bazel project and register a [scala_toolchain](docs/scala_toolchain.md) at the default Scala version (2.12.20)
 
 Then in your BUILD file just add the following so the rules will be available:
 ```starlark
@@ -143,13 +143,13 @@ Previous minor versions may work but are supported only on a best effort basis.
 To configure Scala version you must call `scala_config(scala_version = "2.xx.xx")` and configure 
 dependencies by declaring [scala_toolchain](docs/scala_toolchain.md). 
 For a quick start you can use `scala_repositories()` and `scala_register_toolchains()`, which have 
-dependency providers configured for `2.11.12`, `2.12.18` and `2.13.14` versions.
+dependency providers configured for `2.11.12`, `2.12.20` and `2.13.15` versions.
 
 
 ```starlark
 # WORKSPACE
 load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
-scala_config(scala_version = "2.13.14")
+scala_config(scala_version = "2.13.15")
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
 rules_proto_dependencies()

--- a/dt_patches/dt_patch_test.sh
+++ b/dt_patches/dt_patch_test.sh
@@ -101,6 +101,8 @@ run_test_local test_compiler_patch 2.12.15
 run_test_local test_compiler_patch 2.12.16
 run_test_local test_compiler_patch 2.12.17
 run_test_local test_compiler_patch 2.12.18
+run_test_local test_compiler_patch 2.12.19
+run_test_local test_compiler_patch 2.12.20
 
 run_test_local test_compiler_patch 2.13.0
 run_test_local test_compiler_patch 2.13.1
@@ -115,6 +117,7 @@ run_test_local test_compiler_patch 2.13.10
 run_test_local test_compiler_patch 2.13.11
 run_test_local test_compiler_patch 2.13.12
 run_test_local test_compiler_patch 2.13.14
+run_test_local test_compiler_patch 2.13.15
 
 run_test_local test_compiler_srcjar_error 2.12.11
 run_test_local test_compiler_srcjar_error 2.12.12
@@ -127,7 +130,10 @@ run_test_local test_compiler_srcjar 2.12.15
 run_test_local test_compiler_srcjar 2.12.16
 run_test_local test_compiler_srcjar_nonhermetic 2.12.17
 run_test_local test_compiler_srcjar_nonhermetic 2.12.18
+run_test_local test_compiler_srcjar_nonhermetic 2.12.19
+run_test_local test_compiler_srcjar_nonhermetic 2.12.20
 
 run_test_local test_compiler_srcjar_nonhermetic 2.13.11
 run_test_local test_compiler_srcjar_nonhermetic 2.13.12
 run_test_local test_compiler_srcjar_nonhermetic 2.13.14
+run_test_local test_compiler_srcjar_nonhermetic 2.13.15

--- a/dt_patches/test_dt_patches_user_srcjar/WORKSPACE
+++ b/dt_patches/test_dt_patches_user_srcjar/WORKSPACE
@@ -11,6 +11,17 @@ http_archive(
     ],
 )
 
+http_archive(
+    name = "rules_python",
+    sha256 = "ca77768989a7f311186a29747e3e95c936a41dffac779aff6b443db22290d913",
+    strip_prefix = "rules_python-0.36.0",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.36.0/rules_python-0.36.0.tar.gz",
+)
+
+load("@rules_python//python:repositories.bzl", "py_repositories")
+
+py_repositories()
+
 local_repository(
     name = "io_bazel_rules_scala",
     path = "../..",
@@ -91,6 +102,12 @@ srcjars_by_version = {
     "2.12.18": {
         "url": "https://repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.12.18/scala-compiler-2.12.18-sources.jar?foo",
     },
+    "2.12.19": {
+        "url": "https://repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.12.19/scala-compiler-2.12.19-sources.jar?foo",
+    },
+    "2.12.20": {
+        "url": "https://repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.12.20/scala-compiler-2.12.20-sources.jar?foo",
+    },
     "2.13.11": {
         "url": "https://repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.13.11/scala-compiler-2.13.11-sources.jar?foo",
     },
@@ -99,6 +116,9 @@ srcjars_by_version = {
     },
     "2.13.14": {
         "url": "https://repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.13.14/scala-compiler-2.13.14-sources.jar?foo",
+    },
+    "2.13.15": {
+        "url": "https://repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.13.15/scala-compiler-2.13.15-sources.jar?foo",
     },
 }
 
@@ -111,11 +131,21 @@ rules_scala_toolchain_deps_repositories(
 
 register_toolchains(":dt_scala_toolchain")
 
-load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 
 rules_proto_dependencies()
 
+load("@rules_proto//proto:setup.bzl", "rules_proto_setup")
+
+rules_proto_setup()
+
+load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
+
 rules_proto_toolchains()
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
 
 load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
 

--- a/examples/crossbuild/1_single/BUILD
+++ b/examples/crossbuild/1_single/BUILD
@@ -14,7 +14,7 @@ scala_library(
 scala_test(
     name = "test213",
     srcs = ["test.scala"],
-    scala_version = "2.13.14",
+    scala_version = "2.13.15",
 )
 
 # This one will be compiled by 3.3 compiler (the default one):

--- a/examples/crossbuild/2_deps/BUILD
+++ b/examples/crossbuild/2_deps/BUILD
@@ -19,7 +19,7 @@ scala_binary(
     name = "bin213",
     srcs = ["bin.scala"],  # compiled with 2.13 (as per `scala_version`)
     main_class = "C",
-    scala_version = "2.13.14",
+    scala_version = "2.13.15",
     deps = [
         ":lib",  # compiled 2.13 (as per `scala_version`)
         ":lib211",  # compiled with 2.11 (that target overrides version)

--- a/examples/crossbuild/3_select/BUILD
+++ b/examples/crossbuild/3_select/BUILD
@@ -22,7 +22,7 @@ scala_binary(
     name = "bin2",
     srcs = ["bin.scala"],
     main_class = "B",
-    scala_version = "2.13.14",
+    scala_version = "2.13.15",
     deps = [":lib"],
 )
 
@@ -30,6 +30,6 @@ scala_binary(
     name = "bin3",
     srcs = ["bin.scala"],
     main_class = "B",
-    scala_version = "3.3.1",
+    scala_version = "3.3.4",
     deps = [":lib"],
 )

--- a/examples/crossbuild/WORKSPACE
+++ b/examples/crossbuild/WORKSPACE
@@ -11,6 +11,17 @@ http_archive(
     ],
 )
 
+http_archive(
+    name = "rules_python",
+    sha256 = "ca77768989a7f311186a29747e3e95c936a41dffac779aff6b443db22290d913",
+    strip_prefix = "rules_python-0.36.0",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.36.0/rules_python-0.36.0.tar.gz",
+)
+
+load("@rules_python//python:repositories.bzl", "py_repositories")
+
+py_repositories()
+
 local_repository(
     name = "io_bazel_rules_scala",
     path = "../..",
@@ -19,11 +30,11 @@ local_repository(
 load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
 scala_config(
-    scala_version = "3.3.1",
+    scala_version = "3.3.4",
     scala_versions = [
         "2.11.12",
-        "2.13.14",
-        "3.3.1",
+        "2.13.15",
+        "3.3.4",
     ],
 )
 
@@ -37,11 +48,21 @@ rules_scala_setup()
 
 rules_scala_toolchain_deps_repositories()
 
-load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 
 rules_proto_dependencies()
 
+load("@rules_proto//proto:setup.bzl", "rules_proto_setup")
+
+rules_proto_setup()
+
+load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
+
 rules_proto_toolchains()
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
 
 load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
 

--- a/examples/scala3/WORKSPACE
+++ b/examples/scala3/WORKSPACE
@@ -11,6 +11,17 @@ http_archive(
     ],
 )
 
+http_archive(
+    name = "rules_python",
+    sha256 = "ca77768989a7f311186a29747e3e95c936a41dffac779aff6b443db22290d913",
+    strip_prefix = "rules_python-0.36.0",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.36.0/rules_python-0.36.0.tar.gz",
+)
+
+load("@rules_python//python:repositories.bzl", "py_repositories")
+
+py_repositories()
+
 local_repository(
     name = "io_bazel_rules_scala",
     path = "../..",
@@ -18,7 +29,7 @@ local_repository(
 
 load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
-scala_config(scala_version = "3.3.1")
+scala_config(scala_version = "3.5.2")
 
 load(
     "@io_bazel_rules_scala//scala:scala.bzl",
@@ -30,11 +41,21 @@ rules_scala_setup()
 
 rules_scala_toolchain_deps_repositories(fetch_sources = True)
 
-load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 
 rules_proto_dependencies()
 
+load("@rules_proto//proto:setup.bzl", "rules_proto_setup")
+
+rules_proto_setup()
+
+load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
+
 rules_proto_toolchains()
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
 
 load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
 

--- a/examples/semanticdb/WORKSPACE
+++ b/examples/semanticdb/WORKSPACE
@@ -21,7 +21,7 @@ local_repository(
 
 load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
-scala_config(scala_version = "2.13.14")
+scala_config(scala_version = "2.13.15")
 
 load(
     "@io_bazel_rules_scala//scala:scala.bzl",

--- a/scala_config.bzl
+++ b/scala_config.bzl
@@ -2,7 +2,7 @@ load("//scala:scala_cross_version.bzl", "extract_major_version", "extract_minor_
 
 def _default_scala_version():
     """return the scala version for use in maven coordinates"""
-    return "2.12.18"
+    return "2.12.20"
 
 def _validate_supported_scala_version(scala_major_version, scala_minor_version):
     if scala_major_version == "2.11" and int(scala_minor_version) != 12:

--- a/test/shell/test_coverage_equals_in_target.sh
+++ b/test/shell/test_coverage_equals_in_target.sh
@@ -4,8 +4,13 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . "${dir}"/test_helper.sh
 runner=$(get_test_runner "${1:-local}")
 
+# Default to 2.12.20 for `diff` tests because other versions change the output.
+SCALA_VERSION="${SCALA_VERSION:-2.12.20}"
+
 test_coverage_target_name_contains_equals_sign() {
-    bazel coverage //test/coverage_filename_encoding:name-with-equals
+    bazel coverage \
+      --repo_env="SCALA_VERSION=${SCALA_VERSION}" \
+      //test/coverage_filename_encoding:name-with-equals
     diff test/coverage_filename_encoding/expected-coverage.dat $(bazel info bazel-testlogs)/test/coverage_filename_encoding/name-with-equals/coverage.dat
 }
 

--- a/test/shell/test_coverage_scalatest.sh
+++ b/test/shell/test_coverage_scalatest.sh
@@ -4,15 +4,20 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . "${dir}"/test_helper.sh
 runner=$(get_test_runner "${1:-local}")
 
+# Default to 2.12.20 for `diff` tests because other versions change the output.
+SCALA_VERSION="${SCALA_VERSION:-2.12.20}"
+
 test_coverage_on() {
-    bazel coverage //test/coverage_scalatest:test-scalatest
+    bazel coverage \
+        --repo_env="SCALA_VERSION=${SCALA_VERSION}" \
+        //test/coverage_scalatest:test-scalatest
     diff test/coverage_scalatest/expected-coverage.dat $(bazel info bazel-testlogs)/test/coverage_scalatest/test-scalatest/coverage.dat
 }
 
 test_coverage_includes_test_targets() {
     bazel coverage \
-          --instrument_test_targets=True \
-          //test/coverage_scalatest:test-scalatest
+        --instrument_test_targets=True \
+        //test/coverage_scalatest:test-scalatest
     grep -q "SF:test/coverage_scalatest/TestWithScalaTest.scala" $(bazel info bazel-testlogs)/test/coverage_scalatest/test-scalatest/coverage.dat
 }
 

--- a/test/shell/test_coverage_scalatest_resources.sh
+++ b/test/shell/test_coverage_scalatest_resources.sh
@@ -4,17 +4,21 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . "${dir}"/test_helper.sh
 runner=$(get_test_runner "${1:-local}")
 
+# Default to 2.12.20 for `diff` tests because other versions change the output.
+SCALA_VERSION="${SCALA_VERSION:-2.12.20}"
+
 test_coverage_succeeds_resource_call() {
     bazel coverage \
-          --instrumentation_filter=^//test/coverage_scalatest_resources[:/] \
-          //test/coverage_scalatest_resources/consumer:tests
+        --repo_env="SCALA_VERSION=${SCALA_VERSION}" \
+        --instrumentation_filter=^//test/coverage_scalatest_resources[:/] \
+        //test/coverage_scalatest_resources/consumer:tests
     diff test/coverage_scalatest_resources/expected-coverage.dat $(bazel info bazel-testlogs)/test/coverage_scalatest_resources/consumer/tests/coverage.dat
 }
 
 test_coverage_includes_resource_test_targets() {
     bazel coverage \
-          --instrument_test_targets=True \
-          //test/coverage_scalatest_resources/consumer:tests
+        --instrument_test_targets=True \
+        //test/coverage_scalatest_resources/consumer:tests
     grep -q "SF:test/coverage_scalatest_resources/consumer/src/test/scala/com/example/consumer/ConsumerSpec.scala" $(bazel info bazel-testlogs)/test/coverage_scalatest_resources/consumer/tests/coverage.dat
 }
 

--- a/test/shell/test_coverage_specs2_with_junit.sh
+++ b/test/shell/test_coverage_specs2_with_junit.sh
@@ -4,15 +4,20 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . "${dir}"/test_helper.sh
 runner=$(get_test_runner "${1:-local}")
 
+# Default to 2.12.20 for `diff` tests because other versions change the output.
+SCALA_VERSION="${SCALA_VERSION:-2.12.20}"
+
 test_coverage_on() {
-    bazel coverage //test/coverage_specs2_with_junit:test-specs2-with-junit
+    bazel coverage \
+        --repo_env="SCALA_VERSION=${SCALA_VERSION}" \
+        //test/coverage_specs2_with_junit:test-specs2-with-junit
     diff test/coverage_specs2_with_junit/expected-coverage.dat $(bazel info bazel-testlogs)/test/coverage_specs2_with_junit/test-specs2-with-junit/coverage.dat
 }
 
 test_coverage_includes_test_targets() {
     bazel coverage \
-          --instrument_test_targets=True \
-          //test/coverage_specs2_with_junit:test-specs2-with-junit
+        --instrument_test_targets=True \
+        //test/coverage_specs2_with_junit:test-specs2-with-junit
     grep -q "SF:test/coverage_specs2_with_junit/TestWithSpecs2WithJUnit.scala" $(bazel info bazel-testlogs)/test/coverage_specs2_with_junit/test-specs2-with-junit/coverage.dat
 }
 

--- a/test/shell/test_examples.sh
+++ b/test/shell/test_examples.sh
@@ -30,16 +30,24 @@ function multi_framework_toolchain_example() {
 }
 
 function scala3_1_example() {
-  test_example examples/scala3 "bazel build --repo_env=SCALA_VERSION=3.1.0 //..."
+  test_example examples/scala3 "bazel build --repo_env=SCALA_VERSION=3.1.3 //..."
 }
 
 function scala3_2_example() {
-  test_example examples/scala3 "bazel build --repo_env=SCALA_VERSION=3.2.1 //..."
+  test_example examples/scala3 "bazel build --repo_env=SCALA_VERSION=3.2.2 //..."
 }
 
 function scala3_3_example() {
-  test_example examples/scala3 "bazel build --repo_env=SCALA_VERSION=3.3.1 //..."
+  test_example examples/scala3 "bazel build --repo_env=SCALA_VERSION=3.3.4 //..."
 }
+
+function scala3_4_example() {
+   test_example examples/scala3 "bazel build --repo_env=SCALA_VERSION=3.4.3 //..."
+ }
+
+function scala3_5_example() {
+   test_example examples/scala3 "bazel build --repo_env=SCALA_VERSION=3.5.2 //..."
+ }
 
 function semanticdb_example() {
 
@@ -62,4 +70,6 @@ $runner semanticdb_example
 $runner scala3_1_example
 $runner scala3_2_example
 $runner scala3_3_example
+$runner scala3_4_example
+$runner scala3_5_example
 $runner cross_build_example

--- a/test/shell/test_scala_config.sh
+++ b/test/shell/test_scala_config.sh
@@ -6,19 +6,20 @@ runner=$(get_test_runner "${1:-local}")
 
 test_classpath_contains_2_12() {
   bazel aquery 'mnemonic("Javac", //src/java/io/bazel/rulesscala/scalac:scalac)' \
-   --repo_env=SCALA_VERSION=2.12.18 \
+   --repo_env=SCALA_VERSION=2.12.20 \
    | grep scala-library-2.12
 }
 
 test_classpath_contains_2_13() {
   bazel aquery 'mnemonic("Javac", //src/java/io/bazel/rulesscala/scalac:scalac)' \
-   --repo_env=SCALA_VERSION=2.13.14 \
+   --repo_env=SCALA_VERSION=2.13.15 \
    | grep scala-library-2.13
 }
 
 test_scala_config_content() {
   bazel build --repo_env=SCALA_VERSION=0.0.0 @io_bazel_rules_scala_config//:all 2> /dev/null
-  grep "SCALA_MAJOR_VERSION='0.0'" $(bazel info output_base)/external/io_bazel_rules_scala_config/config.bzl
+  grep "SCALA_MAJOR_VERSION='0.0'" \
+    "$(bazel info output_base)"/external/*io_bazel_rules_scala_config/config.bzl
 }
 
 $runner test_classpath_contains_2_12

--- a/test/shell/test_semanticdb.sh
+++ b/test/shell/test_semanticdb.sh
@@ -24,19 +24,19 @@ test_produces_semanticdb(){
 
 
   if [ $is_bundle -eq 1 ]; then
-    local toolchain="--extra_toolchains=//test/semanticdb:semanticdb_bundle_toolchain"  
+    local toolchain="--extra_toolchains=//test/semanticdb:semanticdb_bundle_toolchain"
   else
     local toolchain="--extra_toolchains=//test/semanticdb:semanticdb_nobundle_toolchain"
   fi
 
   if [ $scala_majver -eq 3 ]; then
-    local version_opt="--repo_env=SCALA_VERSION=3.3.1"
+    local version_opt="--repo_env=SCALA_VERSION=3.3.4"
   fi
 
 
   bazel build //test/semanticdb:semantic_provider_vars_all  ${toolchain}  ${version_opt}
 
-  #semantic_provider_vars.sh contains the SemanticdbInfo data  
+  #semantic_provider_vars.sh contains the SemanticdbInfo data
   . $(bazel info bazel-bin)/test/semanticdb/semantic_provider_vars_all.sh
 
   #Check the Provider variables
@@ -61,7 +61,7 @@ test_produces_semanticdb(){
       echo "Error: SemanticdbInfo.target_root expected to be empty string"
       exit 1
     fi
-  fi 
+  fi
 
   if [[ $scala_majver == 3 ]] && [[ $semanticdb_pluginjarpath != "" ]]; then
     echo "Error: SemanticdbInfo.pluginjarpath expected to be empty for scala 3"
@@ -73,7 +73,7 @@ test_produces_semanticdb(){
   fi
 
   if [ $is_bundle -eq 0 ]; then
-    
+
     semanticdb_path="$(bazel info execution_root)/${semanticdb_target_root}/META-INF/semanticdb/test/semanticdb/"
 
     for arg in $FILES
@@ -85,8 +85,8 @@ test_produces_semanticdb(){
         fi
       done
   fi
-  
-  local JAR="$(bazel info bazel-bin)/test/semanticdb/all_lib.jar" 
+
+  local JAR="$(bazel info bazel-bin)/test/semanticdb/all_lib.jar"
 
   if [ $is_bundle -eq 0 ]; then
     if jar_contains_files $JAR $FILES; then
@@ -110,11 +110,11 @@ test_empty_semanticdb(){
 }
 
 test_no_semanticdb() {
-  #verify no semanticdb files have been generated in the bin dir or bundled in the jar 
+  #verify no semanticdb files have been generated in the bin dir or bundled in the jar
 
   set -e
 
-  local jar="$(bazel info bazel-bin)/test/semanticdb/all_lib.jar" 
+  local jar="$(bazel info bazel-bin)/test/semanticdb/all_lib.jar"
   local targetout_path="$(bazel info bazel-bin)/test/semanticdb"
 
   rm -rf $targetout_path #clean out the output dir for clean slate
@@ -137,7 +137,7 @@ test_no_semanticdb() {
 
 test_semanticdb_handles_removed_sourcefiles() {
   #Ensure absense of bug where bazel failed with 'access denied' on Windows when a source file was removed.
-  
+
   #First add the new scala file, build it, then remove the new scala file, and ensure it builds.
   set -e
 
@@ -151,7 +151,7 @@ test_semanticdb_handles_removed_sourcefiles() {
   mkdir -p $newfile_dir && echo "class D{ val a = 1; }" > $newfilepath
 
 
-  #make sure D.scala was added to the target (sanity check)      
+  #make sure D.scala was added to the target (sanity check)
   local query_result1=$(bazel query "labels(srcs, $rule_label)")
   if [[ $query_result1 != *"$newfilename"* ]] ; then
     echo "$newfilename was not properly added as src for target $rule_label"
@@ -162,30 +162,30 @@ test_semanticdb_handles_removed_sourcefiles() {
 
   #remove the new source file and build it
   rm $newfilepath
-  
+
   #make sure D.scala was properly removed from the target(sanity check)
   local query_result2=$(bazel query "labels(srcs, $rule_label)")
-  if  [[ $query_result2 == *"$newfilename"* ]] ; then    
+  if  [[ $query_result2 == *"$newfilename"* ]] ; then
     echo "$newfilename was not properly removed as src for target $rule_label"
     exit 1
   fi
-  
+
   bazel build $rule_label $toolchainArg
 
-  
+
 }
 
 run_semanticdb_tests() {
   local bundle=1;   local nobundle=0
   local scala3=3;    local scala2=2
-  
-  $runner test_produces_semanticdb $scala2 $bundle 
-  $runner test_produces_semanticdb $scala2 $nobundle 
-  
+
+  $runner test_produces_semanticdb $scala2 $bundle
+  $runner test_produces_semanticdb $scala2 $nobundle
+
   $runner test_empty_semanticdb
 
-  $runner test_produces_semanticdb $scala3 $bundle 
-  $runner test_produces_semanticdb $scala3 $nobundle 
+  $runner test_produces_semanticdb $scala3 $bundle
+  $runner test_produces_semanticdb $scala3 $nobundle
 
   $runner test_no_semanticdb
   $runner test_semanticdb_handles_removed_sourcefiles

--- a/test_cross_build/WORKSPACE
+++ b/test_cross_build/WORKSPACE
@@ -12,20 +12,45 @@ http_archive(
 )
 
 http_archive(
-    name = "rules_proto",
-    sha256 = "8e7d59a5b12b233be5652e3d29f42fba01c7cbab09f6b3a8d0a57ed6d1e9a0da",
-    strip_prefix = "rules_proto-7e4afce6fe62dbff0a4a03450143146f9f2d7488",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/7e4afce6fe62dbff0a4a03450143146f9f2d7488.tar.gz",
-        "https://github.com/bazelbuild/rules_proto/archive/7e4afce6fe62dbff0a4a03450143146f9f2d7488.tar.gz",
-    ],
+    name = "rules_python",
+    sha256 = "ca77768989a7f311186a29747e3e95c936a41dffac779aff6b443db22290d913",
+    strip_prefix = "rules_python-0.36.0",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.36.0/rules_python-0.36.0.tar.gz",
 )
 
-load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+load("@rules_python//python:repositories.bzl", "py_repositories")
+
+py_repositories()
+
+http_archive(
+    name = "rules_proto",
+    sha256 = "6fb6767d1bef535310547e03247f7518b03487740c11b6c6adb7952033fe1295",
+    strip_prefix = "rules_proto-6.0.2",
+    url = "https://github.com/bazelbuild/rules_proto/releases/download/6.0.2/rules_proto-6.0.2.tar.gz",
+)
+
+http_archive(
+    name = "com_google_protobuf",
+    sha256 = "75be42bd736f4df6d702a0e4e4d30de9ee40eac024c4b845d17ae4cc831fe4ae",
+    strip_prefix = "protobuf-21.7",
+    url = "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v21.7.tar.gz",
+)
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 
 rules_proto_dependencies()
 
+load("@rules_proto//proto:setup.bzl", "rules_proto_setup")
+
+rules_proto_setup()
+
+load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
+
 rules_proto_toolchains()
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
 
 local_repository(
     name = "io_bazel_rules_scala",
@@ -35,14 +60,14 @@ local_repository(
 load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
 scala_config(
-    scala_version = "3.1.0",
+    scala_version = "3.1.3",
     scala_versions = [
         "2.11.12",
-        "2.12.18",
-        "2.13.14",
-        "3.1.0",
-        "3.2.1",
-        "3.3.1",
+        "2.12.20",
+        "2.13.15",
+        "3.1.3",
+        "3.2.2",
+        "3.3.4",
     ],
 )
 

--- a/test_cross_build/scalafmt/BUILD
+++ b/test_cross_build/scalafmt/BUILD
@@ -20,7 +20,7 @@ scalafmt_scala_library(
     srcs = ["unformatted/unformatted-library2.scala"],
     config = ":scala2-conf",
     format = True,
-    scala_version = "2.13.14",
+    scala_version = "2.13.15",
 )
 
 scalafmt_scala_library(
@@ -28,7 +28,7 @@ scalafmt_scala_library(
     srcs = ["formatted/formatted-library2.scala"],
     config = ":scala2-conf",
     format = True,
-    scala_version = "2.13.14",
+    scala_version = "2.13.15",
 )
 
 scalafmt_scala_library(
@@ -36,7 +36,7 @@ scalafmt_scala_library(
     srcs = ["unformatted/unformatted-library3.scala"],
     config = ":scala3-conf",
     format = True,
-    scala_version = "3.3.1",
+    scala_version = "3.3.4",
 )
 
 scalafmt_scala_library(
@@ -44,7 +44,7 @@ scalafmt_scala_library(
     srcs = ["formatted/formatted-library3.scala"],
     config = ":scala3-conf",
     format = True,
-    scala_version = "3.3.1",
+    scala_version = "3.3.4",
 )
 
 scalafmt_scala_binary(
@@ -53,7 +53,7 @@ scalafmt_scala_binary(
     config = ":scala2-conf",
     format = True,
     main_class = "UnformattedBinary",
-    scala_version = "2.12.18",
+    scala_version = "2.12.20",
 )
 
 scalafmt_scala_library(
@@ -62,7 +62,7 @@ scalafmt_scala_library(
     config = ":scala2-conf",
     format = True,
     main_class = "UnformattedBinary",
-    scala_version = "2.12.18",
+    scala_version = "2.12.20",
 )
 
 scalafmt_scala_binary(
@@ -71,7 +71,7 @@ scalafmt_scala_binary(
     config = ":scala3-conf",
     format = True,
     main_class = "UnformattedBinary",
-    scala_version = "3.2.1",
+    scala_version = "3.2.2",
 )
 
 scalafmt_scala_library(
@@ -80,7 +80,7 @@ scalafmt_scala_library(
     config = ":scala3-conf",
     format = True,
     main_class = "UnformattedBinary",
-    scala_version = "3.2.1",
+    scala_version = "3.2.2",
 )
 
 scalafmt_scala_test(
@@ -88,7 +88,7 @@ scalafmt_scala_test(
     srcs = ["unformatted/unformatted-test2.scala"],
     config = ":scala2-conf",
     format = True,
-    scala_version = "2.12.18",
+    scala_version = "2.12.20",
 )
 
 scalafmt_scala_test(
@@ -96,10 +96,10 @@ scalafmt_scala_test(
     srcs = ["formatted/formatted-test2.scala"],
     config = ":scala2-conf",
     format = True,
-    scala_version = "2.12.18",
+    scala_version = "2.12.20",
 )
 
-#default scala version is 3.1.0
+#default scala version is 3.1.3
 scalafmt_scala_test(
     name = "unformatted-test3",
     srcs = ["unformatted/unformatted-test3.scala"],

--- a/test_cross_build/version_specific/BUILD
+++ b/test_cross_build/version_specific/BUILD
@@ -7,33 +7,33 @@ load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library")
 scala_library(
     name = "since_3_3",
     srcs = ["since_3_3.scala"],
-    scala_version = "3.3.1",
+    scala_version = "3.3.4",
 )
 
 scala_library(
     name = "before_3_3",
     srcs = ["before_3_3.scala"],
-    scala_version = "3.2.1",
+    scala_version = "3.2.2",
 )
 
 # What's new in 3.2
 scala_library(
     name = "since_3_2",
     srcs = ["since_3_2.scala"],
-    scala_version = "3.2.1",
+    scala_version = "3.2.2",
 )
 
 scala_library(
     name = "before_3_2",
     srcs = ["before_3_2.scala"],
-    scala_version = "3.1.0",
+    scala_version = "3.1.3",
 )
 
 # What's new in 3.1
 scala_library(
     name = "since_3_1",
     srcs = ["since_3_1.scala"],
-    scala_version = "3.1.0",
+    scala_version = "3.1.3",
 )
 
 scala_library(
@@ -43,7 +43,7 @@ scala_library(
         "since_3_2.scala",
         "since_3_3.scala",
     ],
-    scala_version = "3.3.1",
+    scala_version = "3.3.4",
 )
 
 scala_library(
@@ -53,7 +53,7 @@ scala_library(
         "since_3_1.scala",
         "since_3_2.scala",
     ],
-    scala_version = "3.2.1",
+    scala_version = "3.2.2",
 )
 
 scala_library(
@@ -63,5 +63,5 @@ scala_library(
         "before_3_3.scala",
         "since_3_1.scala",
     ],
-    scala_version = "3.1.0",
+    scala_version = "3.1.3",
 )

--- a/test_version.sh
+++ b/test_version.sh
@@ -3,8 +3,9 @@
 set -e
 
 scala_2_11_version="2.11.12"
-scala_2_12_version="2.12.18"
-scala_2_13_version="2.13.14"
+scala_2_12_version="2.12.20"
+scala_2_13_version="2.13.15"
+scala_3_version="3.3.4"
 
 SCALA_VERSION_DEFAULT=$scala_2_11_version
 
@@ -41,10 +42,16 @@ run_in_test_repo() {
 
   cp -r $test_target $NEW_TEST_DIR
 
-  sed \
-      -e "s%\${twitter_scrooge_repositories}%$TWITTER_SCROOGE_REPOSITORIES%" \
+  local scrooge_ws=""
+
+  if [[ -n "$TWITTER_SCROOGE_VERSION" ]]; then
+    local version_param="version = \"$TWITTER_SCROOGE_VERSION\""
+    scrooge_ws="scrooge_repositories($version_param)"
+  fi
+
+  sed -e "s%\${twitter_scrooge_repositories}%${scrooge_ws}\n%" \
       WORKSPACE.template >> $NEW_TEST_DIR/WORKSPACE
-  cp ../.bazelrc $NEW_TEST_DIR/.bazelrc
+  cp ../.bazel{rc,version} $NEW_TEST_DIR/
 
   cd $NEW_TEST_DIR
 
@@ -56,7 +63,7 @@ run_in_test_repo() {
 
   cd ..
   rm -rf $NEW_TEST_DIR
-  
+
   exit $RESPONSE_CODE
 }
 
@@ -83,21 +90,20 @@ test_diagnostic_proto_files() {
 }
 
 test_twitter_scrooge_versions() {
-  local version_under_test=$1
+  local TWITTER_SCROOGE_VERSION="$1"
 
-  local TWITTER_SCROOGE_REPOSITORIES_18_6_0='scrooge_repositories(version = "18.6.0")'
+  case "$TWITTER_SCROOGE_VERSION" in
+  18.6.0|20.9.0)
+    ;;
+  *)
+    echo "Unknown Twitter Scrooge version given $TWITTER_SCROOGE_VERSION"
+    ;;
+  esac
 
-  local TWITTER_SCROOGE_REPOSITORIES_21_2_0='scrooge_repositories(version = "21.2.0")'
-
-  if [ "18.6.0" = $version_under_test ]; then
-    TWITTER_SCROOGE_REPOSITORIES=$TWITTER_SCROOGE_REPOSITORIES_18_6_0
-  elif [ "20.9.0" = $version_under_test ]; then
-    TWITTER_SCROOGE_REPOSITORIES=$TWITTER_SCROOGE_REPOSITORIES_20_9_0
-  else
-    echo "Unknown Twitter Scrooge version given $version_under_test"
-  fi
-
-  run_in_test_repo "bazel test //twitter_scrooge/... --test_arg=${version_under_test}" "scrooge_version" "version_specific_tests_dir/"
+  run_in_test_repo \
+    "bazel test //twitter_scrooge/... --test_arg=${TWITTER_SCROOGE_VERSION}" \
+    "scrooge_version" \
+    "version_specific_tests_dir/"
 }
 
 if ! bazel_loc="$(type -p 'bazel')" || [[ -z "$bazel_loc" ]]; then
@@ -121,17 +127,22 @@ TEST_TIMEOUT=15 $runner test_twitter_scrooge_versions "21.2.0"
 TEST_TIMEOUT=15 $runner test_reporter "${scala_2_11_version}" "${no_diagnostics_reporter_toolchain}"
 TEST_TIMEOUT=15 $runner test_reporter "${scala_2_12_version}" "${no_diagnostics_reporter_toolchain}"
 TEST_TIMEOUT=15 $runner test_reporter "${scala_2_13_version}" "${no_diagnostics_reporter_toolchain}"
+TEST_TIMEOUT=15 $runner test_reporter "${scala_3_version}"    "${no_diagnostics_reporter_toolchain}"
 
 TEST_TIMEOUT=15 $runner test_reporter "${scala_2_11_version}" "${diagnostics_reporter_toolchain}"
 TEST_TIMEOUT=15 $runner test_reporter "${scala_2_12_version}" "${diagnostics_reporter_toolchain}"
 TEST_TIMEOUT=15 $runner test_reporter "${scala_2_13_version}" "${diagnostics_reporter_toolchain}"
+TEST_TIMEOUT=15 $runner test_reporter "${scala_3_version}"    "${diagnostics_reporter_toolchain}"
 
 TEST_TIMEOUT=15 $runner test_reporter "${scala_2_11_version}" "${diagnostics_reporter_and_semanticdb_toolchain}"
 TEST_TIMEOUT=15 $runner test_reporter "${scala_2_12_version}" "${diagnostics_reporter_and_semanticdb_toolchain}"
 TEST_TIMEOUT=15 $runner test_reporter "${scala_2_13_version}" "${diagnostics_reporter_and_semanticdb_toolchain}"
+TEST_TIMEOUT=15 $runner test_reporter "${scala_3_version}"    "${diagnostics_reporter_and_semanticdb_toolchain}"
 
-TEST_TIMEOUT=15 $runner test_diagnostic_proto_files "${scala_2_12_version}" //test_expect_failure/diagnostics_reporter:diagnostics_reporter_toolchain 
-TEST_TIMEOUT=15 $runner test_diagnostic_proto_files "${scala_2_13_version}" //test_expect_failure/diagnostics_reporter:diagnostics_reporter_toolchain 
+TEST_TIMEOUT=15 $runner test_diagnostic_proto_files "${scala_2_12_version}" //test_expect_failure/diagnostics_reporter:diagnostics_reporter_toolchain
+TEST_TIMEOUT=15 $runner test_diagnostic_proto_files "${scala_2_13_version}" //test_expect_failure/diagnostics_reporter:diagnostics_reporter_toolchain
+TEST_TIMEOUT=15 $runner test_diagnostic_proto_files "${scala_3_version}"    //test_expect_failure/diagnostics_reporter:diagnostics_reporter_toolchain 
 
-TEST_TIMEOUT=15 $runner test_diagnostic_proto_files "${scala_2_12_version}" //test_expect_failure/diagnostics_reporter:diagnostics_reporter_and_semanticdb_toolchain 
-TEST_TIMEOUT=15 $runner test_diagnostic_proto_files "${scala_2_13_version}" //test_expect_failure/diagnostics_reporter:diagnostics_reporter_and_semanticdb_toolchain 
+TEST_TIMEOUT=15 $runner test_diagnostic_proto_files "${scala_2_12_version}" //test_expect_failure/diagnostics_reporter:diagnostics_reporter_and_semanticdb_toolchain
+TEST_TIMEOUT=15 $runner test_diagnostic_proto_files "${scala_2_13_version}" //test_expect_failure/diagnostics_reporter:diagnostics_reporter_and_semanticdb_toolchain
+TEST_TIMEOUT=15 $runner test_diagnostic_proto_files "${scala_3_version}"    //test_expect_failure/diagnostics_reporter:diagnostics_reporter_and_semanticdb_toolchain

--- a/third_party/repositories/scala_2_12.bzl
+++ b/third_party/repositories/scala_2_12.bzl
@@ -1,69 +1,144 @@
-scala_version = "2.12.18"
+scala_version = "2.12.20"
 
 artifacts = {
     "io_bazel_rules_scala_scala_library": {
-        "artifact": "org.scala-lang:scala-library:%s" % scala_version,
-        "sha256": "e51e6636c003359e106bea4ad99def70e613c290190c8c84f10f9560dd5b00ae",
+        "artifact": "org.scala-lang:scala-library:2.12.20",
+        "sha256": "4d8a8f984cce31a329a24f10b0bf336f042cb62aeb435290a1b20243154cfccb",
     },
     "io_bazel_rules_scala_scala_compiler": {
-        "artifact": "org.scala-lang:scala-compiler:%s" % scala_version,
-        "sha256": "5680cee34200e8d8ed7965c71d8b1428d3eeb889eb14fec38d40ffbc3761a0d0",
+        "artifact": "org.scala-lang:scala-compiler:2.12.20",
+        "sha256": "c88676d75c69721b717ea6c441ece04fff262abab9d210a2936abc2be3731fa2",
+        "deps": [
+            "@io_bazel_rules_scala_scala_xml",
+            "@io_bazel_rules_scala_scala_library",
+            "@io_bazel_rules_scala_scala_reflect",
+        ],
     },
     "io_bazel_rules_scala_scala_reflect": {
-        "artifact": "org.scala-lang:scala-reflect:%s" % scala_version,
-        "sha256": "d6a24e175246541ffcbc965a231aa1d3bb01d61def196f91495690fabf9783bc",
+        "artifact": "org.scala-lang:scala-reflect:2.12.20",
+        "sha256": "5f1914cdc7a70580ea6038d929ebb25736ecf2234f677e2d47f8a4b2bc81e1fb",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+        ],
     },
     "io_bazel_rules_scala_scalatest": {
         "artifact": "org.scalatest:scalatest_2.12:3.2.9",
         "sha256": "ed4a7e0a2373505ae5b9c4811fa2d2d167f5388556cdcb49bce11f27e18b90fa",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+            "@io_bazel_rules_scala_scala_reflect",
+            "@io_bazel_rules_scala_scalatest_core",
+            "@io_bazel_rules_scala_scalatest_featurespec",
+            "@io_bazel_rules_scala_scalatest_flatspec",
+            "@io_bazel_rules_scala_scalatest_freespec",
+            "@io_bazel_rules_scala_scalatest_funspec",
+            "@io_bazel_rules_scala_scalatest_funsuite",
+            "@io_bazel_rules_scala_scalatest_matchers_core",
+            "@io_bazel_rules_scala_scalatest_mustmatchers",
+            "@io_bazel_rules_scala_scalatest_shouldmatchers",
+        ],
     },
     "io_bazel_rules_scala_scalatest_compatible": {
-        "artifact": "org.scalatest:scalatest-compatible:jar:3.2.9",
+        "artifact": "org.scalatest:scalatest-compatible:3.2.9",
         "sha256": "7e5f1193af2fd88c432c4b80ce3641e4b1d062f421d8a0fcc43af9a19bb7c2eb",
     },
     "io_bazel_rules_scala_scalatest_core": {
         "artifact": "org.scalatest:scalatest-core_2.12:3.2.9",
         "sha256": "8d5bc6b847caaf221fa42cc214dcd1c70fd758aef384a2b6498463db0caf8e3c",
+        "deps": [
+            "@io_bazel_rules_scala_scala_xml",
+            "@io_bazel_rules_scala_scala_library",
+            "@io_bazel_rules_scala_scala_reflect",
+            "@io_bazel_rules_scala_scalactic",
+            "@io_bazel_rules_scala_scalatest_compatible",
+        ],
     },
     "io_bazel_rules_scala_scalatest_featurespec": {
         "artifact": "org.scalatest:scalatest-featurespec_2.12:3.2.9",
         "sha256": "f68bd68cd1f9fc5ccc3bbb004bb843bf01481886952e96e909933960a3365d00",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+            "@io_bazel_rules_scala_scala_reflect",
+            "@io_bazel_rules_scala_scalatest_core",
+        ],
     },
     "io_bazel_rules_scala_scalatest_flatspec": {
         "artifact": "org.scalatest:scalatest-flatspec_2.12:3.2.9",
         "sha256": "bcec89594fda4fc4ffe3c98adaf8e9b7982011433d782b280fe54b6dc8b9f21f",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+            "@io_bazel_rules_scala_scala_reflect",
+            "@io_bazel_rules_scala_scalatest_core",
+        ],
     },
     "io_bazel_rules_scala_scalatest_freespec": {
         "artifact": "org.scalatest:scalatest-freespec_2.12:3.2.9",
         "sha256": "097d551509cbb472d2367ea1b2060b0a27e36bad45ce5828ae2062867b5e8299",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+            "@io_bazel_rules_scala_scala_reflect",
+            "@io_bazel_rules_scala_scalatest_core",
+        ],
     },
     "io_bazel_rules_scala_scalatest_funsuite": {
         "artifact": "org.scalatest:scalatest-funsuite_2.12:3.2.9",
         "sha256": "07b6eb20584bc684646dff58ac02019b97a74c2825644f09d514b7dd7cacf067",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+            "@io_bazel_rules_scala_scala_reflect",
+            "@io_bazel_rules_scala_scalatest_core",
+        ],
     },
     "io_bazel_rules_scala_scalatest_funspec": {
         "artifact": "org.scalatest:scalatest-funspec_2.12:3.2.9",
         "sha256": "3d4d5b6e79c4398d0ff71f1ad4843f7eaf2acd0d197d782ee5f2437eb214ccf1",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+            "@io_bazel_rules_scala_scala_reflect",
+            "@io_bazel_rules_scala_scalatest_core",
+        ],
     },
     "io_bazel_rules_scala_scalatest_matchers_core": {
         "artifact": "org.scalatest:scalatest-matchers-core_2.12:3.2.9",
         "sha256": "44e6bf24fb6fd4fd9419fcaf8d7e64b20c2916659f5d062d33f2de9a48ffdf09",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+            "@io_bazel_rules_scala_scala_reflect",
+            "@io_bazel_rules_scala_scalatest_core",
+        ],
     },
     "io_bazel_rules_scala_scalatest_shouldmatchers": {
         "artifact": "org.scalatest:scalatest-shouldmatchers_2.12:3.2.9",
         "sha256": "2fce7f0f8cbfbc1a3bc65807cf389b01599ee78af459071e679ba5ed4884b4e2",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+            "@io_bazel_rules_scala_scala_reflect",
+            "@io_bazel_rules_scala_scalatest_matchers_core",
+        ],
     },
     "io_bazel_rules_scala_scalatest_mustmatchers": {
         "artifact": "org.scalatest:scalatest-mustmatchers_2.12:3.2.9",
         "sha256": "e443fa6b4b741d1fb21c76ec204df39fec565ea817a3adb2b0b9be7c2a143041",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+            "@io_bazel_rules_scala_scala_reflect",
+            "@io_bazel_rules_scala_scalatest_matchers_core",
+        ],
     },
     "io_bazel_rules_scala_scalactic": {
         "artifact": "org.scalactic:scalactic_2.12:3.2.9",
         "sha256": "a5f01a0ecb7479b4f43e03147094279609d66fdaa04a9cb3238510d7c4dbc22a",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+            "@io_bazel_rules_scala_scala_reflect",
+        ],
     },
     "io_bazel_rules_scala_scala_xml": {
-        "artifact": "org.scala-lang.modules:scala-xml_2.12:1.2.0",
-        "sha256": "1b48dc206f527b7604ef32492ada8e71706c63a65d999e0cabdafdc5793b4d63",
+        "artifact": "org.scala-lang.modules:scala-xml_2.12:2.3.0",
+        "sha256": "4932c56a2d5aae77ae8d7ac6bed1f21d48268fdbac8b4e5f3ca5196ad10fd93e",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+        ],
     },
     "io_bazel_rules_scala_scala_parser_combinators": {
         "artifact": "org.scala-lang.modules:scala-parser-combinators_2.12:1.1.2",
@@ -78,8 +153,8 @@ artifacts = {
         ],
     },
     "org_scalameta_semanticdb_scalac": {
-        "artifact": "org.scalameta:semanticdb-scalac_%s:4.8.4" % scala_version,
-        "sha256": "11d28a73d182453454451aef4768462730f8c3e369df47b224a4ff2e943f1db7",
+        "artifact": "org.scalameta:semanticdb-scalac_2.12.20:4.9.9",
+        "sha256": "7f0e44262b2b1003668f2f51eb0f978ed5a4b94f734e3a6138ce9d7d1a40fc83",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -88,8 +163,8 @@ artifacts = {
         "artifact": "org.scalameta:fastparse-v2_2.12:2.3.1",
         "sha256": "c8ddc110da4b2e3d204e44b2629f4663edeb61094fa7ab4749f2f82b1b0cb026",
         "deps": [
-            "@com_lihaoyi_sourcecode",
             "@com_lihaoyi_geny",
+            "@com_lihaoyi_sourcecode",
         ],
     },
     "org_scalameta_fastparse_utils": {
@@ -101,8 +176,8 @@ artifacts = {
         ],
     },
     "com_lihaoyi_geny": {
-        "artifact": "com.lihaoyi:geny_2.13:0.6.5",
-        "sha256": "ca3857a3f95266e0d87e1a1f26c8592c53c12ac7203f911759415f6c8a43df7d",
+        "artifact": "com.lihaoyi:geny_2.12:0.6.5",
+        "sha256": "9e81e90ab3e380192e04926d546418d825853de8efea12a7f94e0bd04c250419",
     },
     "org_scala_lang_modules_scala_collection_compat": {
         "artifact": "org.scala-lang.modules:scala-collection-compat_2.12:2.4.3",
@@ -160,8 +235,8 @@ artifacts = {
         "sha256": "4c0aa7e223c75c8840c41fc183d4cd3118140a1ee503e3e08ce66ed2794c948f",
     },
     "org_scala_lang_scalap": {
-        "artifact": "org.scala-lang:scalap:2.12.18",
-        "sha256": "9070f22699b961ace3dc8daef1b40aab6a586e10ab2bb4febeb3886654fe0a69",
+        "artifact": "org.scala-lang:scalap:2.12.14",
+        "sha256": "52c37b4e5a37146a9ce5e48b8fb2c39aa0ec7eb867c65708a5cdac786ac79f2a",
         "deps": [
             "@io_bazel_rules_scala_scala_compiler",
         ],
@@ -206,21 +281,21 @@ artifacts = {
         ],
     },
     "com_lihaoyi_sourcecode": {
-        "artifact": "com.lihaoyi:sourcecode_2.12:0.2.5",
-        "sha256": "94f9c383f4d9b8c382de243b0968c02a232be77ff0f1c6677d042717157295ea",
+        "artifact": "com.lihaoyi:sourcecode_2.12:0.2.7",
+        "sha256": "52a8e02b1c90de686994a5f9818987cec44c5df97118e4b59fe2414227099c6a",
     },
     "com_google_protobuf_protobuf_java": {
-        "artifact": "com.google.protobuf:protobuf-java:3.10.0",
-        "sha256": "161d7d61a8cb3970891c299578702fd079646e032329d6c2cabf998d191437c9",
+        "artifact": "com.google.protobuf:protobuf-java:4.28.2",
+        "sha256": "707bccf406f4fc61b841d4700daa8d3e84db8ab499ef3481a060fa6a0f06e627",
     },
     "com_geirsson_metaconfig_core": {
         "artifact": "com.geirsson:metaconfig-core_2.12:0.9.14",
         "sha256": "5efc7a4c5c47df5001c21415ae4e6f37621d731c1895e606029b888728da73c6",
         "deps": [
             "@com_lihaoyi_pprint",
+            "@org_scala_lang_modules_scala_collection_compat",
             "@io_bazel_rules_scala_scala_library",
             "@org_typelevel_paiges_core",
-            "@org_scala_lang_modules_scala_collection_compat",
         ],
     },
     "com_geirsson_metaconfig_typesafe_config": {
@@ -458,8 +533,6 @@ artifacts = {
         "artifact": "com.github.scopt:scopt_2.12:4.0.0-RC2",
         "sha256": "d19a4e8b8c013a56e03bc57bdf87abe6297c974cf907585d00284eae61c6ac91",
     },
-
-    # test only
     "com_twitter__scalding_date": {
         "testonly": True,
         "artifact": "com.twitter:scalding-date_2.12:0.17.0",
@@ -508,7 +581,11 @@ artifacts = {
     },
     "org_typelevel_kind_projector": {
         "testonly": True,
-        "artifact": "org.typelevel:kind-projector_%s:0.13.2" % scala_version,
-        "sha256": "7d4e821b86647c65546c1e3667348e8168c5907e9d4b277cc2badedcd479be44",
+        "artifact": "org.typelevel:kind-projector_2.12.20:0.13.3",
+        "sha256": "98a53122dedd51f79f23ae03eae3258a2e5dbd51c647eaea4942f98c55b052d1",
+        "deps": [
+            "@io_bazel_rules_scala_scala_compiler",
+            "@io_bazel_rules_scala_scala_library",
+        ],
     },
 }

--- a/third_party/repositories/scala_2_13.bzl
+++ b/third_party/repositories/scala_2_13.bzl
@@ -1,89 +1,166 @@
-scala_version = "2.13.14"
+scala_version = "2.13.15"
 
 artifacts = {
     "io_bazel_rules_scala_scala_library": {
-        "artifact": "org.scala-lang:scala-library:%s" % scala_version,
-        "sha256": "43e0ca1583df1966eaf02f0fbddcfb3784b995dd06bfc907209347758ce4b7e3",
+        "artifact": "org.scala-lang:scala-library:2.13.15",
+        "sha256": "8e4dbc3becf70d59c787118f6ad06fab6790136a0699cd6412bc9da3d336944e",
     },
     "io_bazel_rules_scala_scala_compiler": {
-        "artifact": "org.scala-lang:scala-compiler:%s" % scala_version,
-        "sha256": "17b7e1dd95900420816a3bc2788c8c7358c2a3c42899765a5c463a46bfa569a6",
+        "artifact": "org.scala-lang:scala-compiler:2.13.15",
+        "sha256": "4c200cd193c082bec14a2a2dffe6a1ba5f8130b1b27c79ee54c936dfcafc8ed9",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+            "@io_bazel_rules_scala_scala_reflect",
+        ],
     },
     "io_bazel_rules_scala_scala_reflect": {
-        "artifact": "org.scala-lang:scala-reflect:%s" % scala_version,
-        "sha256": "8846baaa8cf43b1b19725ab737abff145ca58d14a4d02e75d71ca8f7ca5f2926",
+        "artifact": "org.scala-lang:scala-reflect:2.13.15",
+        "sha256": "78d0cc350e1ee42d87c6e11cf5b0dc7bf0b70829c00aa38f27bfb019d439dc11",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+        ],
     },
     "io_bazel_rules_scala_scala_parallel_collections": {
-        "artifact": "org.scala-lang.modules:scala-parallel-collections_2.13:1.0.4",
-        "sha256": "68f266c4fa37cb20a76e905ad940e241190ce288b7e4a9877f1dd1261cd1a9a7",
+        "artifact": "org.scala-lang.modules:scala-parallel-collections_2.13:1.0.3",
+        "sha256": "5b9f705652d14005cdc535270547305a4e41d3664f6d15c21b7e0c807f8d6605",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+        ],
     },
     "io_bazel_rules_scala_scalatest": {
-        "artifact": "org.scalatest:scalatest_2.13:3.2.19",
-        "sha256": "c37d97f16172d45b2aef0cebbe59dd2174b7d1ff2c2f272516707cf923015a52",
+        "artifact": "org.scalatest:scalatest_2.13:3.2.9",
+        "sha256": "c5d283a5ec028bf06f83d70e2b88d70a149dd574d19e79e8389b49483914b08b",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+            "@io_bazel_rules_scala_scala_reflect",
+            "@io_bazel_rules_scala_scalatest_core",
+            "@io_bazel_rules_scala_scalatest_featurespec",
+            "@io_bazel_rules_scala_scalatest_flatspec",
+            "@io_bazel_rules_scala_scalatest_freespec",
+            "@io_bazel_rules_scala_scalatest_funspec",
+            "@io_bazel_rules_scala_scalatest_funsuite",
+            "@io_bazel_rules_scala_scalatest_matchers_core",
+            "@io_bazel_rules_scala_scalatest_mustmatchers",
+            "@io_bazel_rules_scala_scalatest_shouldmatchers",
+        ],
     },
     "io_bazel_rules_scala_scalatest_compatible": {
-        "artifact": "org.scalatest:scalatest-compatible:jar:3.2.19",
-        "sha256": "5dc6b8fa5396fe9e1a7c2b72df174a8eb3e92770cdc3e70636d3eba673cd0da3",
+        "artifact": "org.scalatest:scalatest-compatible:3.2.9",
+        "sha256": "7e5f1193af2fd88c432c4b80ce3641e4b1d062f421d8a0fcc43af9a19bb7c2eb",
     },
     "io_bazel_rules_scala_scalatest_core": {
-        "artifact": "org.scalatest:scalatest-core_2.13:3.2.19",
-        "sha256": "30230081d029f6341b83fe7f157d336113e1c97497fe950169293d28a5bf2936",
+        "artifact": "org.scalatest:scalatest-core_2.13:3.2.9",
+        "sha256": "b238f0e42edd471c8d066d25fa925d4c0cfae33b8db1ea79d14ff42047263e5d",
+        "deps": [
+            "@io_bazel_rules_scala_scala_xml",
+            "@io_bazel_rules_scala_scala_library",
+            "@io_bazel_rules_scala_scala_reflect",
+            "@io_bazel_rules_scala_scalactic",
+            "@io_bazel_rules_scala_scalatest_compatible",
+        ],
     },
     "io_bazel_rules_scala_scalatest_featurespec": {
-        "artifact": "org.scalatest:scalatest-featurespec_2.13:3.2.19",
-        "sha256": "58a44e6be12409596feab4d4123900ef2af55d3fcb72033412059ce055e91dee",
+        "artifact": "org.scalatest:scalatest-featurespec_2.13:3.2.9",
+        "sha256": "f8ec83a39554c1e44f6ef5e13d9b87bf8257067b0dad8ee6012fec36e318036d",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+            "@io_bazel_rules_scala_scala_reflect",
+            "@io_bazel_rules_scala_scalatest_core",
+        ],
     },
     "io_bazel_rules_scala_scalatest_flatspec": {
-        "artifact": "org.scalatest:scalatest-flatspec_2.13:3.2.19",
-        "sha256": "de4d28423dc69e91fdc8f3a03a4fb6b443c5626b819c896e5fbe4a73a375654a",
+        "artifact": "org.scalatest:scalatest-flatspec_2.13:3.2.9",
+        "sha256": "6a1bc2f522105b4eda53c225f3d5cbdabbf3e9375136dde57a5b43846369f75a",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+            "@io_bazel_rules_scala_scala_reflect",
+            "@io_bazel_rules_scala_scalatest_core",
+        ],
     },
     "io_bazel_rules_scala_scalatest_freespec": {
-        "artifact": "org.scalatest:scalatest-freespec_2.13:3.2.19",
-        "sha256": "f3e463422cca38117bb48665602543474fbc2c37427b1133a9c34332f895b08a",
+        "artifact": "org.scalatest:scalatest-freespec_2.13:3.2.9",
+        "sha256": "db3467bb0b34c1ca8d9830cf40179e2900ac01d5119f7a1b6bdcef30adb62214",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+            "@io_bazel_rules_scala_scala_reflect",
+            "@io_bazel_rules_scala_scalatest_core",
+        ],
     },
     "io_bazel_rules_scala_scalatest_funsuite": {
-        "artifact": "org.scalatest:scalatest-funsuite_2.13:3.2.19",
-        "sha256": "926aeb37193ad79d0b380160765c9ab61d4367b994c1ab715896fe4961241d5e",
+        "artifact": "org.scalatest:scalatest-funsuite_2.13:3.2.9",
+        "sha256": "d6455470fabc9f3a5a7a50770f6e1a4f4d0114122885637f3df684e5bb501f9d",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+            "@io_bazel_rules_scala_scala_reflect",
+            "@io_bazel_rules_scala_scalatest_core",
+        ],
     },
     "io_bazel_rules_scala_scalatest_funspec": {
-        "artifact": "org.scalatest:scalatest-funspec_2.13:3.2.19",
-        "sha256": "4c682781b67c5daeeebb9e132a78929b824f88747b963b9aa8bd24a0a7d6893b",
+        "artifact": "org.scalatest:scalatest-funspec_2.13:3.2.9",
+        "sha256": "821d13ced0bf96d1470538cbcca3109694148f2637961e5c502639e16ab7eee9",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+            "@io_bazel_rules_scala_scala_reflect",
+            "@io_bazel_rules_scala_scalatest_core",
+        ],
     },
     "io_bazel_rules_scala_scalatest_matchers_core": {
-        "artifact": "org.scalatest:scalatest-matchers-core_2.13:3.2.19",
-        "sha256": "033f16c1143fbe51675d080b13ac319d98581d0331ba3ccebb121e3904a774a3",
+        "artifact": "org.scalatest:scalatest-matchers-core_2.13:3.2.9",
+        "sha256": "b86ed6f0986d005f4d54af5effdb73a18fe5741533f6663631d17a0731b9616f",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+            "@io_bazel_rules_scala_scala_reflect",
+            "@io_bazel_rules_scala_scalatest_core",
+        ],
     },
     "io_bazel_rules_scala_scalatest_shouldmatchers": {
-        "artifact": "org.scalatest:scalatest-shouldmatchers_2.13:3.2.19",
-        "sha256": "64658d736039267baae0108af620617e8ce88b2f4683112e2e31e4ad2a603c0f",
+        "artifact": "org.scalatest:scalatest-shouldmatchers_2.13:3.2.9",
+        "sha256": "39a4eefa409fed5a32eff3647aa4f80628202d966e3cb6a9f01e88dcfae75e4c",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+            "@io_bazel_rules_scala_scala_reflect",
+            "@io_bazel_rules_scala_scalatest_matchers_core",
+        ],
     },
     "io_bazel_rules_scala_scalatest_mustmatchers": {
-        "artifact": "org.scalatest:scalatest-mustmatchers_2.13:3.2.19",
-        "sha256": "8ebbd5c12843d75f15283f31c35994b6e733ce737f666b05528fa8b6e67ad32e",
+        "artifact": "org.scalatest:scalatest-mustmatchers_2.13:3.2.9",
+        "sha256": "e170d4ff75f0e96458b7ec072accd40ff585f9e444b5831ba84287ff2da70f2c",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+            "@io_bazel_rules_scala_scala_reflect",
+            "@io_bazel_rules_scala_scalatest_matchers_core",
+        ],
     },
     "io_bazel_rules_scala_scalactic": {
-        "artifact": "org.scalactic:scalactic_2.13:3.2.19",
-        "sha256": "c27c33de17d450e29e66c16c5af4cfa33e8ffcf03c124f0a3d249d848cccd4af",
+        "artifact": "org.scalactic:scalactic_2.13:3.2.9",
+        "sha256": "dcb853409202fee6f8e7216b363aab5b68edc07a51d27b61d5bf3fdf4418c9da",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+            "@io_bazel_rules_scala_scala_reflect",
+        ],
     },
     "io_bazel_rules_scala_scala_xml": {
-        "artifact": "org.scala-lang.modules:scala-xml_2.13:2.3.0",
-        "sha256": "4b4d6698c74bff84a105102bbf58390980dc7bb8c40bdea4bc727040b3f966bd",
+        "artifact": "org.scala-lang.modules:scala-xml_2.13:1.3.0",
+        "sha256": "6d96d45a7fc6fc7ab69bdbac841b48cf67ab109f048c8db375ae4effae524f39",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+        ],
     },
     "io_bazel_rules_scala_scala_parser_combinators": {
-        "artifact": "org.scala-lang.modules:scala-parser-combinators_2.13:2.4.0",
-        "sha256": "e36dccdc21fd4bc770907a9e126d7e3901e71a191eb9ea8e93a0227774e0945d",
+        "artifact": "org.scala-lang.modules:scala-parser-combinators_2.13:1.1.2",
+        "sha256": "5c285b72e6dc0a98e99ae0a1ceeb4027dab9adfa441844046bd3f19e0efdcb54",
     },
     "org_scalameta_common": {
-        "artifact": "org.scalameta:common_2.13:4.9.9",
-        "sha256": "be66ba789863c65abfc9c1e448339ce915f2bc778daf348d884a967e8eb473ee",
+        "artifact": "org.scalameta:common_2.13:4.4.27",
+        "sha256": "882d82f7f547aec5d9b55ef3173188ce3d55b28272cd9e36b6558f55e1389d26",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library",
         ],
     },
     "org_scalameta_semanticdb_scalac": {
-        "artifact": "org.scalameta:semanticdb-scalac_%s:4.9.9" % scala_version,
-        "sha256": "1adfd051c4b4e1c69a49492cbcf558011beba78e79aaeef1319d29e8408e341d",
+        "artifact": "org.scalameta:semanticdb-scalac_2.13.15:4.9.9",
+        "sha256": "409194fee7eeb3da25733f6fc0c2d62b9ef53ddecdc50b6c922fdc695b250fe7",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -92,8 +169,8 @@ artifacts = {
         "artifact": "org.scalameta:fastparse-v2_2.13:2.3.1",
         "sha256": "8fca8597ad6d7c13c48009ee13bbe80c176b08ab12e68af54a50f7f69d8447c5",
         "deps": [
-            "@com_lihaoyi_sourcecode",
             "@com_lihaoyi_geny",
+            "@com_lihaoyi_sourcecode",
         ],
     },
     "org_scalameta_fastparse_utils": {
@@ -105,39 +182,39 @@ artifacts = {
         ],
     },
     "com_lihaoyi_geny": {
-        "artifact": "com.lihaoyi:geny_2.13:1.1.1",
-        "sha256": "20af231c222fc71c29e06b3cd8d9190a16b412da83cc49fb0b778cf2dc6f94d2",
+        "artifact": "com.lihaoyi:geny_2.13:0.6.5",
+        "sha256": "ca3857a3f95266e0d87e1a1f26c8592c53c12ac7203f911759415f6c8a43df7d",
     },
     "org_scala_lang_modules_scala_collection_compat": {
-        "artifact": "org.scala-lang.modules:scala-collection-compat_2.13:2.12.0",
-        "sha256": "befff482233cd7f9a7ca1e1f5a36ede421c018e6ce82358978c475d45532755f",
+        "artifact": "org.scala-lang.modules:scala-collection-compat_2.13:2.4.3",
+        "sha256": "7f71f1404ce6b54b2f854b0f6c5a5e06c0d915043e44b697a25adf2da573a09e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
     },
     "org_scalameta_parsers": {
-        "artifact": "org.scalameta:parsers_2.13:4.9.9",
-        "sha256": "ab4198d993b4214d9b98277f96c4ac76a72b87a1fea8df96e9be8e3e98176d7a",
+        "artifact": "org.scalameta:parsers_2.13:4.4.27",
+        "sha256": "f375cbda5c0ee65bcd9af8a9a2a2afb042ca244d79880db904aa03c98a0d7553",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scalameta_trees",
         ],
     },
     "org_scalameta_scalafmt_core": {
-        "artifact": "org.scalameta:scalafmt-core_2.13:3.8.3",
-        "sha256": "c214d16a746ceab8ac47b97c18d2817f726174dd58da75d43472d045ddc25009",
+        "artifact": "org.scalameta:scalafmt-core_2.13:3.0.0",
+        "sha256": "c71697f9b6bf41109f7f31ddddd924198b0769e94240aad2aa05006071607b1e",
         "deps": [
             "@com_geirsson_metaconfig_core",
             "@com_geirsson_metaconfig_typesafe_config",
+            "@io_bazel_rules_scala_scala_parallel_collections",
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
             "@org_scalameta_scalameta",
-            "@io_bazel_rules_scala_scala_parallel_collections",
         ],
     },
     "org_scalameta_scalameta": {
-        "artifact": "org.scalameta:scalameta_2.13:4.9.9",
-        "sha256": "01a3c1130202400dbcf4ea0f42374c8e392b9199716ddf605217f4bf1f61cb1d",
+        "artifact": "org.scalameta:scalameta_2.13:4.4.27",
+        "sha256": "878cfea72e1df90bf8a49cdac0deed8226b0b96d11d537131400f0e17efcd1f5",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scala_lang_scalap",
@@ -145,8 +222,8 @@ artifacts = {
         ],
     },
     "org_scalameta_trees": {
-        "artifact": "org.scalameta:trees_2.13:4.9.9",
-        "sha256": "d016cde916b19d6c814ac296544a1882b96664ac03e5ef27019a518482c3db49",
+        "artifact": "org.scalameta:trees_2.13:4.4.27",
+        "sha256": "9a78a879c0fa88cdfed6e2dc83c47c3d0f9994927be84dffa44f0bbe18ca311a",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scalameta_common",
@@ -154,33 +231,33 @@ artifacts = {
         ],
     },
     "org_typelevel_paiges_core": {
-        "artifact": "org.typelevel:paiges-core_2.13:0.4.4",
-        "sha256": "ffbd59d3648e71c5b8f4474a54121fb3512707e7901245831669aa9e85f3bbf0",
+        "artifact": "org.typelevel:paiges-core_2.13:0.4.1",
+        "sha256": "3c4968ee11aa929d937fc666db62cf7bbc3909ba08c853909d93fea08b214569",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
     },
     "com_typesafe_config": {
-        "artifact": "com.typesafe:config:1.4.3",
-        "sha256": "8ada4c185ce72416712d63e0b5afdc5f009c0cdf405e5f26efecdf156aa5dfb6",
+        "artifact": "com.typesafe:config:1.4.1",
+        "sha256": "4c0aa7e223c75c8840c41fc183d4cd3118140a1ee503e3e08ce66ed2794c948f",
     },
     "org_scala_lang_scalap": {
-        "artifact": "org.scala-lang:scalap:2.13.14",
-        "sha256": "b92a0f32ae645064f828005f883ce4aeec110fe6971f1b030643ff005a77e7c0",
+        "artifact": "org.scala-lang:scalap:2.13.6",
+        "sha256": "bbfa4ab0603f510b16114371a35b9c34d20946edfc1aa8f3fd31014b9f06b5b1",
         "deps": [
             "@io_bazel_rules_scala_scala_compiler",
         ],
     },
     "com_thesamet_scalapb_lenses": {
-        "artifact": "com.thesamet.scalapb:lenses_2.13:0.11.17",
-        "sha256": "4abe3fe573b8505a633414b0fbbcae4240250690ba48a9d4a6eeb3dfc3302ddf",
+        "artifact": "com.thesamet.scalapb:lenses_2.13:0.9.0",
+        "sha256": "10830d6511fc21b997c4acdde6f6700e87ee6791cbe6278f5acd7b352670a88f",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
     },
     "com_thesamet_scalapb_scalapb_runtime": {
-        "artifact": "com.thesamet.scalapb:scalapb-runtime_2.13:0.11.17",
-        "sha256": "fe91faf58bccef68be348e76cab339a5fe2c215e48f7bd8f836190449ed94077",
+        "artifact": "com.thesamet.scalapb:scalapb-runtime_2.13:0.9.0",
+        "sha256": "10830d6511fc21b997c4acdde6f6700e87ee6791cbe6278f5acd7b352670a88f",
         "deps": [
             "@com_google_protobuf_protobuf_java",
             "@com_lihaoyi_fastparse",
@@ -189,48 +266,48 @@ artifacts = {
         ],
     },
     "com_lihaoyi_fansi": {
-        "artifact": "com.lihaoyi:fansi_2.13:0.5.0",
-        "sha256": "fcae26580f7d6e72adbd6e5c504bb1715fbe3f5fb814d70e84bc5427a835e42c",
+        "artifact": "com.lihaoyi:fansi_2.13:0.2.12",
+        "sha256": "d92e5b0ea4d946f6567db57fbeffc34d4020597c675cb804ade6cc38a198ff35",
         "deps": [
             "@com_lihaoyi_sourcecode",
         ],
     },
     "com_lihaoyi_fastparse": {
-        "artifact": "com.lihaoyi:fastparse_2.13:3.1.1",
-        "sha256": "ff3f37dad0f89c9cff494cb984edc122a3c282f063790949e825ae039dcad9d5",
+        "artifact": "com.lihaoyi:fastparse_2.13:2.1.3",
+        "sha256": "5064d3984aab8c48d2dbd6285787ac5c6d84a6bebfc02c6d431ce153cf91dec1",
         "deps": [
             "@com_lihaoyi_sourcecode",
         ],
     },
     "com_lihaoyi_pprint": {
-        "artifact": "com.lihaoyi:pprint_2.13:0.9.0",
-        "sha256": "5dd36b65addcd47bccc68d36dd00bee93e2def439f1a36d02a450308e8d9a3d3",
+        "artifact": "com.lihaoyi:pprint_2.13:0.6.4",
+        "sha256": "618585ee50a3b3939ed8a24d9b165d925e8a926cec9e368bacd1b7feee6b32c2",
         "deps": [
             "@com_lihaoyi_fansi",
             "@com_lihaoyi_sourcecode",
         ],
     },
     "com_lihaoyi_sourcecode": {
-        "artifact": "com.lihaoyi:sourcecode_2.13:0.4.2",
-        "sha256": "fbace2b994a7184f6b38ee98630be61f21948008a4a56cd83c7f86c1c1de743d",
+        "artifact": "com.lihaoyi:sourcecode_2.13:0.2.7",
+        "sha256": "a639a90e2d21bbafd8a5e213c65442aad200ee086951605cbda8835bc6ef11d3",
     },
     "com_google_protobuf_protobuf_java": {
-        "artifact": "com.google.protobuf:protobuf-java:4.27.3",
-        "sha256": "d02f863a90a3ffc77d5eeec031c18e579f30c7cb98f3f3a814fe8b88c43d3bc8",
+        "artifact": "com.google.protobuf:protobuf-java:4.28.2",
+        "sha256": "707bccf406f4fc61b841d4700daa8d3e84db8ab499ef3481a060fa6a0f06e627",
     },
     "com_geirsson_metaconfig_core": {
-        "artifact": "com.geirsson:metaconfig-core_2.13:0.12.0",
-        "sha256": "2c91199ae5b206afdd52538f8c4da67c1794bcce0b5b06cf25679db00cf32c19",
+        "artifact": "com.geirsson:metaconfig-core_2.13:0.9.14",
+        "sha256": "aab728395055a095d1134f76191d40076eaf9d5c9ffc722005da044580269acf",
         "deps": [
             "@com_lihaoyi_pprint",
+            "@org_scala_lang_modules_scala_collection_compat",
             "@io_bazel_rules_scala_scala_library",
             "@org_typelevel_paiges_core",
-            "@org_scala_lang_modules_scala_collection_compat",
         ],
     },
     "com_geirsson_metaconfig_typesafe_config": {
-        "artifact": "com.geirsson:metaconfig-typesafe-config_2.13:0.12.0",
-        "sha256": "b4c5dbf863dadde363d8bd24333ce1091fec94fc5b88efd04607a26f3eab61b8",
+        "artifact": "com.geirsson:metaconfig-typesafe-config_2.13:0.9.14",
+        "sha256": "e4ca5cfb44dc3ee0fff222eafbe86c7f431b0f692b7fd0b832da521462a693cd",
         "deps": [
             "@com_geirsson_metaconfig_core",
             "@com_typesafe_config",
@@ -238,20 +315,20 @@ artifacts = {
         ],
     },
     "io_bazel_rules_scala_org_openjdk_jmh_jmh_core": {
-        "artifact": "org.openjdk.jmh:jmh-core:1.37",
-        "sha256": "dc0eaf2bbf0036a70b60798c785d6e03a9daf06b68b8edb0f1ba9eb3421baeb3",
+        "artifact": "org.openjdk.jmh:jmh-core:1.36",
+        "sha256": "f90974e37d0da8886b5c05e6e3e7e20556900d747c5a41c1023b47c3301ea73c",
     },
     "io_bazel_rules_scala_org_openjdk_jmh_jmh_generator_asm": {
-        "artifact": "org.openjdk.jmh:jmh-generator-asm:1.37",
-        "sha256": "de29bacc5c3a413215800f57de9017fdda1b3cb6e5359ea0c84ebe13c9610222",
+        "artifact": "org.openjdk.jmh:jmh-generator-asm:1.36",
+        "sha256": "7460b11b823dee74b3e19617d35d5911b01245303d6e31c30f83417cfc2f54b5",
     },
     "io_bazel_rules_scala_org_openjdk_jmh_jmh_generator_reflection": {
-        "artifact": "org.openjdk.jmh:jmh-generator-reflection:1.37",
-        "sha256": "a0421dbbe5e77690df2dfdef98618b62852d816bbb814c5cbd0b4d464bff32b0",
+        "artifact": "org.openjdk.jmh:jmh-generator-reflection:1.36",
+        "sha256": "a9c72760e12c199e2a2c28f1a126ebf0cc5b51c0b58d46472596fc32f7f92534",
     },
     "io_bazel_rules_scala_org_ows2_asm_asm": {
-        "artifact": "org.ow2.asm:asm:9.7",
-        "sha256": "adf46d5e34940bdf148ecdd26a9ee8eea94496a72034ff7141066b3eea5c4e9d",
+        "artifact": "org.ow2.asm:asm:9.0",
+        "sha256": "0df97574914aee92fd349d0cb4e00f3345d45b2c239e0bb50f0a90ead47888e0",
     },
     "io_bazel_rules_scala_net_sf_jopt_simple_jopt_simple": {
         "artifact": "net.sf.jopt-simple:jopt-simple:5.0.4",
@@ -262,185 +339,185 @@ artifacts = {
         "sha256": "1e56d7b058d28b65abd256b8458e3885b674c1d588fa43cd7d1cbb9c7ef2b308",
     },
     "io_bazel_rules_scala_junit_junit": {
-        "artifact": "junit:junit:4.13.2",
-        "sha256": "8e495b634469d64fb8acfa3495a065cbacc8a0fff55ce1e31007be4c16dc57d3",
+        "artifact": "junit:junit:4.12",
+        "sha256": "59721f0805e223d84b90677887d9ff567dc534d7c502ca903c0c2b17f05c116a",
     },
     "io_bazel_rules_scala_org_hamcrest_hamcrest_core": {
-        "artifact": "org.hamcrest:hamcrest-core:3.0",
-        "sha256": "b78a3a81692f421cc01fc17ded9a45e9fb6f3949c712f8ec4d01da6b8c06bc6e",
+        "artifact": "org.hamcrest:hamcrest-core:1.3",
+        "sha256": "66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9",
     },
     "io_bazel_rules_scala_org_specs2_specs2_common": {
-        "artifact": "org.specs2:specs2-common_2.13:4.20.8",
-        "sha256": "b39b2424545e5d37143a7eae598d9b9084ffdbdb2b7b24ec89b8665bf190907a",
+        "artifact": "org.specs2:specs2-common_2.13:4.10.3",
+        "sha256": "51636fb6a904b3c807de0673f283a971379c9886e03aedbecbf5d787b22346b0",
         "deps": [
             "@io_bazel_rules_scala_org_specs2_specs2_fp",
         ],
     },
     "io_bazel_rules_scala_org_specs2_specs2_core": {
-        "artifact": "org.specs2:specs2-core_2.13:4.20.8",
-        "sha256": "ce7e74b558f918114c086b87021a441c980b00964e45bbc24a167e1e6c6c7f81",
+        "artifact": "org.specs2:specs2-core_2.13:4.10.3",
+        "sha256": "9cc55eb11781c9b77689cf8175795fad34b060718b04a225fffb0613a181256b",
         "deps": [
             "@io_bazel_rules_scala_org_specs2_specs2_common",
             "@io_bazel_rules_scala_org_specs2_specs2_matcher",
         ],
     },
     "io_bazel_rules_scala_org_specs2_specs2_fp": {
-        "artifact": "org.specs2:specs2-fp_2.13:4.20.8",
-        "sha256": "8f50a66880fa88ca499b78d19b4133e34832a1578d180dd9af9b3dab3b4cd5c1",
+        "artifact": "org.specs2:specs2-fp_2.13:4.10.3",
+        "sha256": "48a908b345c93a3387ddd157ab338686513f450c7dd8afe0f32b6edc7ff15239",
     },
     "io_bazel_rules_scala_org_specs2_specs2_matcher": {
-        "artifact": "org.specs2:specs2-matcher_2.13:4.20.8",
-        "sha256": "196c945e3afc44b4d696fdf8d402dacc8aac7b36e790af7e32557ef7691a9eb4",
+        "artifact": "org.specs2:specs2-matcher_2.13:4.10.3",
+        "sha256": "754465f58dad8f59b3bb299d5dc127027bf0c0c9ad25250260fc95abd705363b",
         "deps": [
             "@io_bazel_rules_scala_org_specs2_specs2_common",
         ],
     },
     "io_bazel_rules_scala_org_specs2_specs2_junit": {
-        "artifact": "org.specs2:specs2-junit_2.13:4.20.8",
-        "sha256": "2071a325ba34766b9360e9a72ab74615c7116c3e3ae7f4955c5e5a774ea92114",
+        "artifact": "org.specs2:specs2-junit_2.13:4.10.3",
+        "sha256": "49c4e7cf5483aada90852314983fc046f72092da1a4e7900ace6574444f581ea",
         "deps": [
             "@io_bazel_rules_scala_org_specs2_specs2_core",
         ],
     },
     "scala_proto_rules_scalapb_plugin": {
-        "artifact": "com.thesamet.scalapb:compilerplugin_2.13:0.11.17",
-        "sha256": "d36b84059289c7aa2f2bf08eeab7e85084fcf72bf58b337edf167c73218880d7",
+        "artifact": "com.thesamet.scalapb:compilerplugin_2.13:0.9.7",
+        "sha256": "ac29c2f01b0b1e39c4226915000505643d586234d586247e1fd97133e20bcc60",
     },
     "scala_proto_rules_protoc_bridge": {
-        "artifact": "com.thesamet.scalapb:protoc-bridge_2.13:0.9.7",
-        "sha256": "403f0e7223c8fd052cff0fbf977f3696c387a696a3a12d7b031d95660c7552f5",
+        "artifact": "com.thesamet.scalapb:protoc-bridge_2.13:0.7.14",
+        "sha256": "0704f2379374205e7130018e3df6b3d50a4d330c3e447ca39b5075ecb4c93cd1",
     },
     "scala_proto_rules_scalapb_runtime": {
-        "artifact": "com.thesamet.scalapb:scalapb-runtime_2.13:0.11.17",
-        "sha256": "fe91faf58bccef68be348e76cab339a5fe2c215e48f7bd8f836190449ed94077",
+        "artifact": "com.thesamet.scalapb:scalapb-runtime_2.13:0.9.7",
+        "sha256": "8026485011c53d35eb427ac5c09ed34c283b355d8a6363eae68b3f165bee34a0",
     },
     "scala_proto_rules_scalapb_runtime_grpc": {
-        "artifact": "com.thesamet.scalapb:scalapb-runtime-grpc_2.13:0.11.17",
-        "sha256": "c03687c038f2a45bb413551519542069a59faf322de29fd1f9e06f2dd65003d0",
+        "artifact": "com.thesamet.scalapb:scalapb-runtime-grpc_2.13:0.9.7",
+        "sha256": "950984d4a3b21925d3156dd98cddb4e7c2f429aad81aa25bb5a3792d41fd7c76",
     },
     "scala_proto_rules_scalapb_lenses": {
-        "artifact": "com.thesamet.scalapb:lenses_2.13:0.11.17",
-        "sha256": "4abe3fe573b8505a633414b0fbbcae4240250690ba48a9d4a6eeb3dfc3302ddf",
+        "artifact": "com.thesamet.scalapb:lenses_2.13:0.9.7",
+        "sha256": "5f43b371b2738a81eff129fd2071ce3e5b3aa30909de90e6bb6e25c3de6c312d",
     },
     "scala_proto_rules_scalapb_fastparse": {
-        "artifact": "com.lihaoyi:fastparse_2.13:3.1.1",
-        "sha256": "ff3f37dad0f89c9cff494cb984edc122a3c282f063790949e825ae039dcad9d5",
+        "artifact": "com.lihaoyi:fastparse_2.13:2.1.3",
+        "sha256": "5064d3984aab8c48d2dbd6285787ac5c6d84a6bebfc02c6d431ce153cf91dec1",
     },
     "scala_proto_rules_grpc_core": {
-        "artifact": "io.grpc:grpc-core:1.66.0",
-        "sha256": "136b7a7c411a45089dc2b26f0f032f4ae466d9b5d3bfe3a513421d6f35d2c2bd",
+        "artifact": "io.grpc:grpc-core:1.24.0",
+        "sha256": "8fc900625a9330b1c155b5423844d21be0a5574fe218a63170a16796c6f7880e",
     },
     "scala_proto_rules_grpc_api": {
-        "artifact": "io.grpc:grpc-api:1.66.0",
-        "sha256": "8fadb1f4f0a18971c082497f34cbb78a51897ca8af4b212aa2a99c7de9ad995c",
+        "artifact": "io.grpc:grpc-api:1.24.0",
+        "sha256": "553978366e04ee8ddba64afde3b3cf2ac021a2f3c2db2831b6491d742b558598",
     },
     "scala_proto_rules_grpc_stub": {
-        "artifact": "io.grpc:grpc-stub:1.66.0",
-        "sha256": "39a32906304c7f442dfa56dfc6ea88887287fb398621d549e15dfdeaffae194a",
+        "artifact": "io.grpc:grpc-stub:1.24.0",
+        "sha256": "eaa9201896a77a0822e26621b538c7154f00441a51c9b14dc9e1ec1f2acfb815",
     },
     "scala_proto_rules_grpc_protobuf": {
-        "artifact": "io.grpc:grpc-protobuf:1.66.0",
-        "sha256": "5942dd582be6c0319bf2af9dd94886f631927b7126d57c8d84fbddd796fd7eb5",
+        "artifact": "io.grpc:grpc-protobuf:1.24.0",
+        "sha256": "88cd0838ea32893d92cb214ea58908351854ed8de7730be07d5f7d19025dd0bc",
     },
     "scala_proto_rules_grpc_netty": {
-        "artifact": "io.grpc:grpc-netty:1.66.0",
-        "sha256": "77f7c0ccd77df1d62a8508fef6676fa80b388e3ef4f67fceb99a7d5eaa73b7c9",
+        "artifact": "io.grpc:grpc-netty:1.24.0",
+        "sha256": "8478333706ba442a354c2ddb8832d80a5aef71016e8a9cf07e7bf6e8c298f042",
     },
     "scala_proto_rules_grpc_context": {
-        "artifact": "io.grpc:grpc-context:1.66.0",
-        "sha256": "7b7521aa2116014d08dc08825e13d70eac8eb646d09dd44980b6f4d1883e6713",
+        "artifact": "io.grpc:grpc-context:1.24.0",
+        "sha256": "1f0546e18789f7445d1c5a157010a11bc038bbb31544cdb60d9da3848efcfeea",
     },
     "scala_proto_rules_perfmark_api": {
-        "artifact": "io.perfmark:perfmark-api:0.27.0",
-        "sha256": "c7b478503ec524e55df19b424d46d27c8a68aeb801664fadd4f069b71f52d0f6",
+        "artifact": "io.perfmark:perfmark-api:0.17.0",
+        "sha256": "816c11409b8a0c6c9ce1cda14bed526e7b4da0e772da67c5b7b88eefd41520f9",
     },
     "scala_proto_rules_guava": {
-        "artifact": "com.google.guava:guava:33.2.1-android",
-        "sha256": "6b55fbe6ffee621454c03df7bea720d189789e136391a524e29506ff40654180",
+        "artifact": "com.google.guava:guava:26.0-android",
+        "sha256": "1d044ebb866ef08b7d04e998b4260c9b52fab6e6d6b68d207859486bb3686cd5",
     },
     "scala_proto_rules_google_instrumentation": {
-        "artifact": "com.google.instrumentation:instrumentation-api:0.4.3",
-        "sha256": "9502d5622fea56e5b3fbe4a5263ad3bfd93487869813304c36831e1cb1d88bd5",
+        "artifact": "com.google.instrumentation:instrumentation-api:0.3.0",
+        "sha256": "671f7147487877f606af2c7e39399c8d178c492982827305d3b1c7f5b04f1145",
     },
     "scala_proto_rules_netty_codec": {
-        "artifact": "io.netty:netty-codec:4.1.112.Final",
-        "sha256": "72db4f93629f7ea520d2998c08e2b1d69f9c6a4792b53da5e9a001d24c78b151",
+        "artifact": "io.netty:netty-codec:4.1.32.Final",
+        "sha256": "dbd6cea7d7bf5a2604e87337cb67c9468730d599be56511ed0979aacb309f879",
     },
     "scala_proto_rules_netty_codec_http": {
-        "artifact": "io.netty:netty-codec-http:4.1.112.Final",
-        "sha256": "21b502d1374d6992728d004e0c1c95544d46d971f55ea78dcb854ce1ac0c83bc",
+        "artifact": "io.netty:netty-codec-http:4.1.32.Final",
+        "sha256": "db2c22744f6a4950d1817e4e1a26692e53052c5d54abe6cceecd7df33f4eaac3",
     },
     "scala_proto_rules_netty_codec_socks": {
-        "artifact": "io.netty:netty-codec-socks:4.1.112.Final",
-        "sha256": "069f14507676282a8c4b871b27332aa4491c16339ec0e86f4d86d45a953b51f5",
+        "artifact": "io.netty:netty-codec-socks:4.1.32.Final",
+        "sha256": "fe2f2e97d6c65dc280623dcfd24337d8a5c7377049c120842f2c59fb83d7408a",
     },
     "scala_proto_rules_netty_codec_http2": {
-        "artifact": "io.netty:netty-codec-http2:4.1.112.Final",
-        "sha256": "7f73efc845e8818d71da23b21dc65d69132dd0e12ed0e80cc937bd79ab7d5749",
+        "artifact": "io.netty:netty-codec-http2:4.1.32.Final",
+        "sha256": "4d4c6cfc1f19efb969b9b0ae6cc977462d202867f7dcfee6e9069977e623a2f5",
     },
     "scala_proto_rules_netty_handler": {
-        "artifact": "io.netty:netty-handler:4.1.112.Final",
-        "sha256": "ea4d6062a5fb10a6e2364d8bbdebc1cfa814f1fc9f910ef57e5caf02fb15c588",
+        "artifact": "io.netty:netty-handler:4.1.32.Final",
+        "sha256": "07d9756e48b5f6edc756e33e8b848fb27ff0b1ae087dab5addca6c6bf17cac2d",
     },
     "scala_proto_rules_netty_buffer": {
-        "artifact": "io.netty:netty-buffer:4.1.112.Final",
-        "sha256": "bc182c48f5369d48cd8370d2ab0c5b8d99dd8ffa4a0f8ac701652d57bd380eff",
+        "artifact": "io.netty:netty-buffer:4.1.32.Final",
+        "sha256": "8ac0e30048636bd79ae205c4f9f5d7544290abd3a7ed39d8b6d97dfe3795afc1",
     },
     "scala_proto_rules_netty_transport": {
-        "artifact": "io.netty:netty-transport:4.1.112.Final",
-        "sha256": "d38e31624d25ca790ee413d529c152170217ebedbcdcf61164fa6291f3a56c92",
+        "artifact": "io.netty:netty-transport:4.1.32.Final",
+        "sha256": "175bae0d227d7932c0c965c983efbb3cf01f39abe934f5c4071d0319784715fb",
     },
     "scala_proto_rules_netty_resolver": {
-        "artifact": "io.netty:netty-resolver:4.1.112.Final",
-        "sha256": "6b4ac9f3b67f562f0770d57c389279ff9c708eb401e1a3635f52297f0f897edc",
+        "artifact": "io.netty:netty-resolver:4.1.32.Final",
+        "sha256": "9b4a19982047a95ea4791a7ad7ad385c7a08c2ac75f0a3509cc213cb32a726ae",
     },
     "scala_proto_rules_netty_common": {
-        "artifact": "io.netty:netty-common:4.1.112.Final",
-        "sha256": "b03967f32c65de5ed339b97729170e0289b22ffa5729e7f45f68bf6b431fb567",
+        "artifact": "io.netty:netty-common:4.1.32.Final",
+        "sha256": "cc993e660f8f8e3b033f1d25a9e2f70151666bdf878d460a6508cb23daa696dc",
     },
     "scala_proto_rules_netty_handler_proxy": {
-        "artifact": "io.netty:netty-handler-proxy:4.1.112.Final",
-        "sha256": "91f7c93dfe4b7a13198d40af39edac0adb0c33f08d9759242997b89176130c8c",
+        "artifact": "io.netty:netty-handler-proxy:4.1.32.Final",
+        "sha256": "10d1081ed114bb0e76ebbb5331b66a6c3189cbdefdba232733fc9ca308a6ea34",
     },
     "scala_proto_rules_opencensus_api": {
-        "artifact": "io.opencensus:opencensus-api:0.31.1",
-        "sha256": "f1474d47f4b6b001558ad27b952e35eda5cc7146788877fc52938c6eba24b382",
+        "artifact": "io.opencensus:opencensus-api:0.22.1",
+        "sha256": "62a0503ee81856ba66e3cde65dee3132facb723a4fa5191609c84ce4cad36127",
     },
     "scala_proto_rules_opencensus_impl": {
-        "artifact": "io.opencensus:opencensus-impl:0.31.1",
-        "sha256": "8249a5c7a6bb172a48c12dae9da30305e5b91ae7a900b2ff4234b75debff4c88",
+        "artifact": "io.opencensus:opencensus-impl:0.22.1",
+        "sha256": "9e8b209da08d1f5db2b355e781b9b969b2e0dab934cc806e33f1ab3baed4f25a",
     },
     "scala_proto_rules_disruptor": {
-        "artifact": "com.lmax:disruptor:4.0.0.RC1",
-        "sha256": "946f79e5a116dc5651e67220578a497bc241fd004ddf91066884f5b14e99f2e0",
+        "artifact": "com.lmax:disruptor:3.4.2",
+        "sha256": "f412ecbb235c2460b45e63584109723dea8d94b819c78c9bfc38f50cba8546c0",
     },
     "scala_proto_rules_opencensus_impl_core": {
-        "artifact": "io.opencensus:opencensus-impl-core:0.31.1",
-        "sha256": "78ecb82f6694a03e76a75b984c533b9449c731d9832782bafb906df925d71983",
+        "artifact": "io.opencensus:opencensus-impl-core:0.22.1",
+        "sha256": "04607d100e34bacdb38f93c571c5b7c642a1a6d873191e25d49899668514db68",
     },
     "scala_proto_rules_opencensus_contrib_grpc_metrics": {
-        "artifact": "io.opencensus:opencensus-contrib-grpc-metrics:0.31.1",
-        "sha256": "c862a1d783652405512e26443f6139e6586f335086e5e1f1dca2b0c4e338a174",
+        "artifact": "io.opencensus:opencensus-contrib-grpc-metrics:0.22.1",
+        "sha256": "3f6f4d5bd332c516282583a01a7c940702608a49ed6e62eb87ef3b1d320d144b",
     },
     "io_bazel_rules_scala_mustache": {
-        "artifact": "com.github.spullara.mustache.java:compiler:0.9.14",
-        "sha256": "99a7e7855609135006f078e6de7ee69daad9c42f98e679d56f80653cb17526b9",
+        "artifact": "com.github.spullara.mustache.java:compiler:0.8.18",
+        "sha256": "ddabc1ef897fd72319a761d29525fd61be57dc25d04d825f863f83cc89000e66",
     },
     "io_bazel_rules_scala_guava": {
         "artifact": "com.google.guava:guava:21.0",
         "sha256": "972139718abc8a4893fa78cba8cf7b2c903f35c97aaf44fa3031b0669948b480",
     },
     "libthrift": {
-        "artifact": "org.apache.thrift:libthrift:0.20.0",
-        "sha256": "52b4ccf7d4cd5cab6429b2507c31d8c1a358ea9d8ae0ba109dd2d865856e7c12",
+        "artifact": "org.apache.thrift:libthrift:0.8.0",
+        "sha256": "adea029247c3f16e55e29c1708b897812fd1fe335ac55fe3903e5d2f428ef4b3",
     },
     "io_bazel_rules_scala_scrooge_core": {
-        "artifact": "com.twitter:scrooge-core_2.13:24.2.0",
-        "sha256": "992ac9bacebc82d0fa8b91b9d439718af8fda182b4d21a5051eafdca2830232a",
+        "artifact": "com.twitter:scrooge-core_2.13:21.2.0",
+        "sha256": "a93f179b96e13bd172e5164c587a3645122f45f6d6370304e06d52e2ab0e456f",
     },
     "io_bazel_rules_scala_scrooge_generator": {
-        "artifact": "com.twitter:scrooge-generator_2.13:24.2.0",
-        "sha256": "6539e8791806edccbcd414dc0c7fec0f8a4264f9c6ef6befd4149026f83e2bca",
+        "artifact": "com.twitter:scrooge-generator_2.13:21.2.0",
+        "sha256": "1293391da7df25497cad7c56cf8ecaeb672496a548d144d7a2a1cfcf748bed6c",
         "runtime_deps": [
             "@io_bazel_rules_scala_guava",
             "@io_bazel_rules_scala_mustache",
@@ -448,32 +525,30 @@ artifacts = {
         ],
     },
     "io_bazel_rules_scala_util_core": {
-        "artifact": "com.twitter:util-core_2.13:24.2.0",
-        "sha256": "078f2b590926b8f2e5e7cea2466aafe26275f0d733194bc7d046daf56928adbf",
+        "artifact": "com.twitter:util-core_2.13:21.2.0",
+        "sha256": "da8e149b8f0646316787b29f6e254250da10b4b31d9a96c32e42f613574678cd",
     },
     "io_bazel_rules_scala_util_logging": {
-        "artifact": "com.twitter:util-logging_2.13:24.2.0",
-        "sha256": "b050e7f5b85289b0065ffaabc8bea389d57c877cb0a13380dbff28ea3b16a948",
+        "artifact": "com.twitter:util-logging_2.13:21.2.0",
+        "sha256": "90bd8318329907dcf7e161287473e27272b38ee6857e9d56ee8a1958608cc49d",
     },
     "io_bazel_rules_scala_javax_annotation_api": {
         "artifact": "javax.annotation:javax.annotation-api:1.3.2",
         "sha256": "e04ba5195bcd555dc95650f7cc614d151e4bcd52d29a10b8aa2197f3ab89ab9b",
     },
     "io_bazel_rules_scala_scopt": {
-        "artifact": "com.github.scopt:scopt_2.13:4.1.0",
-        "sha256": "2e5037bda974630b046794274e344273919abf4727acfcd86352617dce68f82b",
+        "artifact": "com.github.scopt:scopt_2.13:4.0.0-RC2",
+        "sha256": "07c1937cba53f7509d2ac62a0fc375943a3e0fef346625414c15d41b5a6cfb34",
     },
-
-    # test only
     "com_twitter__scalding_date": {
         "testonly": True,
-        "artifact": "com.twitter:scalding-date_2.12:0.17.4",
-        "sha256": "f9034bc2b1cc05429df8ceb7d7748d53bcc9ada9b2cacf24830b095cfc29e845",
+        "artifact": "com.twitter:scalding-date_2.13:0.17.0",
+        "sha256": "973a7198121cc8dac9eeb3f325c93c497fe3b682f68ba56e34c1b210af7b15b4",
     },
     "org_typelevel__cats_core": {
         "testonly": True,
-        "artifact": "org.typelevel:cats-core_2.13:2.12.0",
-        "sha256": "0d57ee8ad9d969245ece5a0030f46066bd48898107edfba4b0295123daeff65d",
+        "artifact": "org.typelevel:cats-core_2.13:2.2.0",
+        "sha256": "6058d02418e4eb5f1919a1156d63d2d1b93f2c6190b1a1806ee2b73f8726a92f",
     },
     "com_google_guava_guava_21_0_with_file": {
         "testonly": True,
@@ -482,23 +557,23 @@ artifacts = {
     },
     "com_github_jnr_jffi_native": {
         "testonly": True,
-        "artifact": "com.github.jnr:jffi:jar:native:1.3.13",
-        "sha256": "78df5fb05d7e2541b867bedc538b18840245a601bb2160fa26824bb67ed93878",
+        "artifact": "com.github.jnr:jffi:jar:native:1.2.17",
+        "sha256": "4eb582bc99d96c8df92fc6f0f608fd123d278223982555ba16219bf8be9f75a9",
     },
     "org_apache_commons_commons_lang_3_5": {
         "testonly": True,
-        "artifact": "org.apache.commons:commons-lang3:3.16.0",
-        "sha256": "08709dd74d602b705ce4017d26544210056a4ba583d5b20c09373406fe7a00f8",
+        "artifact": "org.apache.commons:commons-lang3:3.5",
+        "sha256": "8ac96fc686512d777fca85e144f196cd7cfe0c0aec23127229497d1a38ff651c",
     },
     "org_springframework_spring_core": {
         "testonly": True,
-        "artifact": "org.springframework:spring-core:6.1.11",
-        "sha256": "1f87efb8202638aa87dc01da3a7ff7cc2a72442b2e00bb5e420d20e4ccb05204",
+        "artifact": "org.springframework:spring-core:5.1.5.RELEASE",
+        "sha256": "f771b605019eb9d2cf8f60c25c050233e39487ff54d74c93d687ea8de8b7285a",
     },
     "org_springframework_spring_tx": {
         "testonly": True,
-        "artifact": "org.springframework:spring-tx:6.1.11",
-        "sha256": "6e54e6e7b7d66359cee3366299e34fdbac3ef5f2d0ea6da158f80179ff9ac5c9",
+        "artifact": "org.springframework:spring-tx:5.1.5.RELEASE",
+        "sha256": "666f72b73c7e6b34e5bb92a0d77a14cdeef491c00fcb07a1e89eb62b08500135",
         "deps": [
             "@org_springframework_spring_core",
         ],
@@ -513,7 +588,11 @@ artifacts = {
     },
     "org_typelevel_kind_projector": {
         "testonly": True,
-        "artifact": "org.typelevel:kind-projector_%s:0.13.3" % scala_version,
-        "sha256": "fc40476381233d532ed26b64a3643c1bda792d2900a7df697d676dde82e4408d",
+        "artifact": "org.typelevel:kind-projector_2.13.15:0.13.3",
+        "sha256": "569fec54deba82cd143f05a6a0456c9e3bf56bff310b0968f0adb5fb3b352d92",
+        "deps": [
+            "@io_bazel_rules_scala_scala_compiler",
+            "@io_bazel_rules_scala_scala_library",
+        ],
     },
 }

--- a/third_party/repositories/scala_3_5.bzl
+++ b/third_party/repositories/scala_3_5.bzl
@@ -1,4 +1,4 @@
-scala_version = "3.3.4"
+scala_version = "3.5.2"
 
 artifacts = {
     "io_bazel_rules_scala_scala_library_2": {
@@ -6,31 +6,31 @@ artifacts = {
         "sha256": "c6a879e4973a60f6162668542a33eaccc2bb565d1c934fb061c5844259131dd1",
     },
     "io_bazel_rules_scala_scala_library": {
-        "artifact": "org.scala-lang:scala3-library_3:3.3.4",
-        "sha256": "d95184acfcd814da2e051378e4962c653f4b468f4086452ab427af030482bd3c",
+        "artifact": "org.scala-lang:scala3-library_3:3.5.2",
+        "sha256": "3d1117bb660d3721d2a01345e064d96fd6eca5e7a4e574eecaa409c064432cba",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
     },
     "io_bazel_rules_scala_scala_compiler": {
-        "artifact": "org.scala-lang:scala3-compiler_3:3.3.4",
-        "sha256": "2cca65fdb92e2cc393786cae61b4f7bcb9032ad4be61f9cebae1dca72997e52f",
+        "artifact": "org.scala-lang:scala3-compiler_3:3.5.2",
+        "sha256": "ba6b31f2d63048d5e4bac45facf42811da2093ae60e90932ab72778e439243b2",
         "deps": [
             "@io_bazel_rules_scala_scala_asm",
             "@org_scala_sbt_compiler_interface",
         ],
     },
     "io_bazel_rules_scala_scala_interfaces": {
-        "artifact": "org.scala-lang:scala3-interfaces:3.3.4",
-        "sha256": "fe056c10a217353e14aa62076d2bbd957ebd82e02fb445ca5546ae8ea9d40caa",
+        "artifact": "org.scala-lang:scala3-interfaces:3.5.2",
+        "sha256": "36bb7c369bfd245dce403c886e1f004a574d0b7935d50cf5a9bf6ddefd1d2b0e",
     },
     "io_bazel_rules_scala_scala_tasty_core": {
-        "artifact": "org.scala-lang:tasty-core_3:3.3.4",
-        "sha256": "13d44693d6f2d38e0595954d11234c0373d6d0e689a8151b06878c5b631d57d5",
+        "artifact": "org.scala-lang:tasty-core_3:3.5.2",
+        "sha256": "b380158748e147f4e44654ad16003c89599ddd456eac29f9686cb6d5515067f3",
     },
     "io_bazel_rules_scala_scala_asm": {
-        "artifact": "org.scala-lang.modules:scala-asm:9.6.0-scala-1",
-        "sha256": "bf16f8b69e89cadab550bce266a052780af7f1eb29dd1c04c3bd014113752c12",
+        "artifact": "org.scala-lang.modules:scala-asm:9.7.0-scala-2",
+        "sha256": "823cd3a46e289c69e37994e03aee3864e1e059aacb3e0bf34f536b3669b61772",
     },
     "io_bazel_rules_scala_scala_parallel_collections": {
         "artifact": "org.scala-lang.modules:scala-parallel-collections_2.13:1.0.3",


### PR DESCRIPTION
### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->
Brought in some of the changes from https://github.com/bazelbuild/rules_scala/commit/487c2fa51915e31b9c609244ab09b76fd5063797#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5

I couldn't just merge master wholesale or cherry-pick because there are other post 6.6.0 changes that we aren't ready to take in yet. Once 6.7.0 is released, we can merge the full upstream here. Tested in [private repo]

<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->
